### PR TITLE
Groups refacto to implément members logic, with members implémentation  

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -152,13 +152,13 @@ func (srv *accountsAPI) DeleteAccount(ctx context.Context, in *accountsv1.Delete
 	return &accountsv1.DeleteAccountResponse{}, nil
 }
 
-func (srv *accountsAPI) ListAccount(ctx context.Context, in *accountsv1.ListAccountRequest) (*accountsv1.ListAccountResponse, error) {
+func (srv *accountsAPI) ListAccount(ctx context.Context, in *accountsv1.ListAccountsRequest) (*accountsv1.ListAccountsResponse, error) {
 	_, err := srv.authenticate(ctx)
 	if err != nil {
 		return nil, status.Error(codes.Unauthenticated, err.Error())
 	}
 
-	accounts, err := srv.repo.List(ctx, &models.ManyAccountsFilter{}, &models.Pagination{Offset: in.Paginate.Offset, Limit: in.Paginate.Limit})
+	accounts, err := srv.repo.List(ctx, &models.ManyAccountsFilter{}, &models.Pagination{Offset: int64(in.Offset), Limit: int64(in.Limit)})
 	if err != nil {
 		return nil, statusFromModelError(err)
 	}
@@ -171,7 +171,7 @@ func (srv *accountsAPI) ListAccount(ctx context.Context, in *accountsv1.ListAcco
 		}
 		accountsResp = append(accountsResp, elem)
 	}
-	return &accountsv1.ListAccountResponse{Accounts: accountsResp}, nil
+	return &accountsv1.ListAccountsResponse{Accounts: accountsResp}, nil
 }
 
 func (srv *accountsAPI) Authenticate(ctx context.Context, in *accountsv1.AuthenticateRequest) (*accountsv1.AuthenticateResponse, error) {

--- a/accounts.go
+++ b/accounts.go
@@ -152,10 +152,19 @@ func (srv *accountsAPI) DeleteAccount(ctx context.Context, in *accountsv1.Delete
 	return &accountsv1.DeleteAccountResponse{}, nil
 }
 
-func (srv *accountsAPI) ListAccount(ctx context.Context, in *accountsv1.ListAccountsRequest) (*accountsv1.ListAccountsResponse, error) {
+func (srv *accountsAPI) ListAccounts(ctx context.Context, in *accountsv1.ListAccountsRequest) (*accountsv1.ListAccountsResponse, error) {
 	_, err := srv.authenticate(ctx)
 	if err != nil {
 		return nil, status.Error(codes.Unauthenticated, err.Error())
+	}
+
+	err = validators.ValidateListRequest(in)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "could not validate list accounts request")
+	}
+
+	if in.Limit == 0 {
+		in.Limit = 20
 	}
 
 	accounts, err := srv.repo.List(ctx, &models.ManyAccountsFilter{}, &models.Pagination{Offset: int64(in.Offset), Limit: int64(in.Limit)})

--- a/groups.go
+++ b/groups.go
@@ -117,6 +117,33 @@ func (srv *groupsAPI) UpdateGroup(ctx context.Context, in *accountsv1.UpdateGrou
 	return &accountsv1.UpdateGroupResponse{Group: &returnedGroup}, nil
 }
 
+func (srv *groupsAPI) GetGroup(ctx context.Context, in *accountsv1.GetGroupRequest) (*accountsv1.GetGroupResponse, error) {
+	_, err := srv.authenticate(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Unauthenticated, err.Error())
+	}
+
+	err = validators.ValidateGetGroup(in)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "could not get Group")
+	}
+
+	group, err := srv.groupRepo.Get(ctx, &models.OneGroupFilter{ID: in.GroupId})
+
+	if err != nil {
+		srv.logger.Error("failed get group from group id", zap.Error(err))
+	}
+
+	return &accountsv1.GetGroupResponse{
+		Group: &accountsv1.Group{
+			Id:          group.ID,
+			Description: *group.Description,
+			Name:        *group.Name,
+			CreatedAt:   timestamppb.New(group.CreatedAt),
+		},
+	}, nil
+}
+
 func (srv *groupsAPI) ListGroups(ctx context.Context, in *accountsv1.ListGroupsRequest) (*accountsv1.ListGroupsResponse, error) {
 	err := validators.ValidateListGroups(in)
 	if err != nil {

--- a/groups.go
+++ b/groups.go
@@ -6,7 +6,6 @@ import (
 	accountsv1 "accounts-service/protorepo/noted/accounts/v1"
 	"accounts-service/validators"
 	"context"
-	"time"
 
 	"github.com/jinzhu/copier"
 	"github.com/mennanov/fmutils"
@@ -36,12 +35,12 @@ func (srv *groupsAPI) CreateGroup(ctx context.Context, in *accountsv1.CreateGrou
 
 	accountId := token.UserID.String()
 
-	group, err := srv.groupRepo.Create(ctx, &models.GroupPayload{Name: &in.Name, Description: &in.Description, CreatedAt: time.Now().UTC()})
+	group, err := srv.groupRepo.Create(ctx, &models.GroupPayload{Name: &in.Name, Description: &in.Description})
 	if err != nil {
 		return nil, statusFromModelError(err)
 	}
 
-	member := models.MemberPayload{AccountID: &accountId, GroupID: &group.ID, Role: auth.RoleAdmin, CreatedAt: time.Now().UTC()}
+	member := models.MemberPayload{AccountID: &accountId, GroupID: &group.ID, Role: auth.RoleAdmin}
 	_, err = srv.memberRepo.Create(ctx, &member)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())

--- a/groups.go
+++ b/groups.go
@@ -6,6 +6,7 @@ import (
 	accountsv1 "accounts-service/protorepo/noted/accounts/v1"
 	"accounts-service/validators"
 	"context"
+
 	"github.com/jinzhu/copier"
 	"github.com/mennanov/fmutils"
 	"go.uber.org/zap"
@@ -17,22 +18,23 @@ import (
 type groupsAPI struct {
 	accountsv1.UnimplementedGroupsAPIServer
 
-	auth   auth.Service
-	logger *zap.Logger
-	repo   models.GroupsRepository
+	auth       auth.Service
+	logger     *zap.Logger
+	groupRepo  models.GroupsRepository
+	memberRepo models.MembersRepository
 }
 
 var _ accountsv1.GroupsAPIServer = &groupsAPI{}
 
 func (srv *groupsAPI) CreateGroup(ctx context.Context, in *accountsv1.CreateGroupRequest) (*accountsv1.CreateGroupResponse, error) {
-	token, err := srv.authenticate(ctx)
-	if err != nil {
-		return nil, err
-	}
+	// token, err := srv.authenticate(ctx)
+	// if err != nil {
+	// 	return nil, err
+	// }
 
-	id := token.UserID.String()
+	// id := token.UserID.String()
 
-	group, err := srv.repo.Create(ctx, &models.GroupPayload{Name: &in.Name, OwnerID: id, Description: &in.Description, Members: &[]models.GroupMember{{ID: token.UserID.String()}}})
+	group, err := srv.groupRepo.Create(ctx, &models.GroupPayload{Name: &in.Name, Description: &in.Description})
 	if err != nil {
 		return nil, statusFromModelError(err)
 	}
@@ -42,7 +44,6 @@ func (srv *groupsAPI) CreateGroup(ctx context.Context, in *accountsv1.CreateGrou
 			Id:          group.ID,
 			Name:        *group.Name,
 			Description: *group.Description,
-			OwnerId:     group.OwnerID,
 		},
 	}, nil
 }
@@ -53,13 +54,13 @@ func (srv *groupsAPI) DeleteGroup(ctx context.Context, in *accountsv1.DeleteGrou
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	token, err := srv.authenticate(ctx)
-	if err != nil {
-		return nil, err
-	}
-	id := token.UserID.String()
+	// token, err := srv.authenticate(ctx)
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// id := token.UserID.String()
 
-	err = srv.repo.Delete(ctx, &models.OneGroupFilter{ID: in.Id, OwnerID: id})
+	err = srv.groupRepo.Delete(ctx, &models.OneGroupFilter{ID: in.GroupId})
 	if err != nil {
 		return nil, statusFromModelError(err)
 	}
@@ -80,7 +81,7 @@ func (srv *groupsAPI) UpdateGroup(ctx context.Context, in *accountsv1.UpdateGrou
 		return nil, status.Error(codes.InvalidArgument, "invalid field mask")
 	}
 
-	acc, err := srv.repo.Get(ctx, &models.OneGroupFilter{ID: in.Group.Id})
+	acc, err := srv.groupRepo.Get(ctx, &models.OneGroupFilter{ID: in.Group.Id})
 	if err != nil {
 		return nil, statusFromModelError(err)
 	}
@@ -95,73 +96,13 @@ func (srv *groupsAPI) UpdateGroup(ctx context.Context, in *accountsv1.UpdateGrou
 	}
 	proto.Merge(&protoGroup, in.Group)
 
-	updatedGroup, err := srv.repo.Update(ctx, &models.OneGroupFilter{ID: acc.ID}, &models.GroupPayload{OwnerID: protoGroup.OwnerId, Name: &protoGroup.Name, Description: &protoGroup.Description})
+	updatedGroup, err := srv.groupRepo.Update(ctx, &models.OneGroupFilter{ID: acc.ID}, &models.GroupPayload{Name: &protoGroup.Name, Description: &protoGroup.Description})
 	if err != nil {
 		return nil, statusFromModelError(err)
 	}
 
-	var groupMembers []*accountsv1.GroupMember
-	for _, members := range *updatedGroup.Members {
-		elem := &accountsv1.GroupMember{AccountId: members.ID}
-		if err != nil {
-			srv.logger.Error("failed to decode account", zap.Error(err))
-		}
-		groupMembers = append(groupMembers, elem)
-	}
-	returnedGroup := accountsv1.Group{Id: updatedGroup.ID, OwnerId: updatedGroup.OwnerID, Name: *updatedGroup.Name, Description: *updatedGroup.Description, Members: groupMembers}
+	returnedGroup := accountsv1.Group{Id: updatedGroup.ID, Name: *updatedGroup.Name, Description: *updatedGroup.Description}
 	return &accountsv1.UpdateGroupResponse{Group: &returnedGroup}, nil
-}
-
-func (srv *groupsAPI) JoinGroup(ctx context.Context, in *accountsv1.JoinGroupRequest) (*accountsv1.JoinGroupResponse, error) {
-	token, err := srv.authenticate(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	acc, err := srv.repo.Get(ctx, &models.OneGroupFilter{ID: in.Id})
-	if err != nil {
-		return nil, statusFromModelError(err)
-	}
-
-	newMember := *acc.Members
-	newMember = append(newMember, models.GroupMember{ID: token.UserID.String()})
-
-	_, err = srv.repo.Update(ctx, &models.OneGroupFilter{ID: in.Id}, &models.GroupPayload{Members: &newMember})
-	if err != nil {
-		return nil, statusFromModelError(err)
-	}
-	return &accountsv1.JoinGroupResponse{}, nil
-}
-
-func (srv *groupsAPI) AddNoteToGroup(ctx context.Context, in *accountsv1.AddNoteToGroupRequest) (*accountsv1.AddNoteToGroupResponse, error) {
-	// id, err := uuid.Parse(in.Id)
-	// if err != nil {
-	// 	srv.logger.Error("failed to convert uuid from string", zap.Error(err))
-	// 	return nil, status.Error(codes.Internal, "could not join group")
-	// }
-
-	// noteId, err := uuid.Parse(in.NoteId)
-	// if err != nil {
-	// 	srv.logger.Error("failed to convert uuid from string", zap.Error(err))
-	// 	return nil, status.Error(codes.Internal, "could not join group")
-	// }
-
-	// acc, err := srv.repo.Get(ctx, &models.OneGroupFilter{ID: id.String()})
-	// if err != nil {
-	// 	srv.logger.Error("failed to get group", zap.Error(err))
-	// 	return nil, status.Error(codes.Internal, "could not join group")
-	// }
-
-	// newNote := *acc.Notes
-	// newNote = append(newNote, models.Note{ID: noteId.String()})
-
-	// err = srv.repo.Update(ctx, &models.OneGroupFilter{ID: id.String()}, &models.GroupPayload{Notes: &newNote})
-	// if err != nil {
-	// 	srv.logger.Error("failed to update group", zap.Error(err))
-	// 	return nil, status.Error(codes.Internal, "could not join group")
-	// }
-
-	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
 // TODO: This function is duplicated from accountsService.authenticate().

--- a/groups.go
+++ b/groups.go
@@ -34,14 +34,14 @@ func (srv *groupsAPI) CreateGroup(ctx context.Context, in *accountsv1.CreateGrou
 		return nil, status.Error(codes.Unauthenticated, err.Error())
 	}
 
-	account_id := token.UserID.String()
+	accountId := token.UserID.String()
 
 	group, err := srv.groupRepo.Create(ctx, &models.GroupPayload{Name: &in.Name, Description: &in.Description, CreatedAt: time.Now().UTC()})
 	if err != nil {
 		return nil, statusFromModelError(err)
 	}
 
-	member := models.MemberPayload{Account: &account_id, Group: &group.ID, Role: auth.RoleAdmin, CreatedAt: time.Now().UTC()}
+	member := models.MemberPayload{AccountID: &accountId, GroupID: &group.ID, Role: auth.RoleAdmin, CreatedAt: time.Now().UTC()}
 	_, err = srv.memberRepo.Create(ctx, &member)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -72,7 +72,7 @@ func (srv *groupsAPI) DeleteGroup(ctx context.Context, in *accountsv1.DeleteGrou
 	if err != nil {
 		return nil, statusFromModelError(err)
 	}
-	memberFilter := models.MemberFilter{Group: &in.GroupId}
+	memberFilter := models.MemberFilter{GroupID: &in.GroupId}
 	err = srv.memberRepo.DeleteMany(ctx, &memberFilter)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -129,14 +129,14 @@ func (srv *groupsAPI) ListGroups(ctx context.Context, in *accountsv1.ListGroupsR
 		return nil, status.Error(codes.Unauthenticated, err.Error())
 	}
 
-	memberFromGroups, err := srv.memberRepo.List(ctx, &models.MemberFilter{Account: &in.AccountId})
+	memberFromGroups, err := srv.memberRepo.List(ctx, &models.MemberFilter{AccountID: &in.AccountId})
 	if err != nil {
 		return nil, status.Error(codes.Unauthenticated, "could not list groups member from groups Id")
 	}
 
 	var groups []*accountsv1.Group
 	for _, member := range memberFromGroups {
-		group, err := srv.groupRepo.Get(ctx, &models.OneGroupFilter{ID: *member.Group})
+		group, err := srv.groupRepo.Get(ctx, &models.OneGroupFilter{ID: *member.GroupID})
 
 		if err != nil {
 			srv.logger.Error("failed get group from member id", zap.Error(err))

--- a/groups_test.go
+++ b/groups_test.go
@@ -90,12 +90,12 @@ func newMembersDatabaseSchema() *memdb.DBSchema {
 					"account_id": {
 						Name:    "account_id",
 						Unique:  false,
-						Indexer: &memdb.StringFieldIndex{Field: "Account"},
+						Indexer: &memdb.StringFieldIndex{Field: "AccountID"},
 					},
 					"group_id": {
 						Name:    "group_id",
 						Unique:  false,
-						Indexer: &memdb.StringFieldIndex{Field: "Group"},
+						Indexer: &memdb.StringFieldIndex{Field: "GroupID"},
 					},
 					"created_at": {
 						Name:    "created_at",

--- a/groups_test.go
+++ b/groups_test.go
@@ -3,9 +3,11 @@ package main
 import (
 	"accounts-service/auth"
 	"accounts-service/models/memory"
+	accountsv1 "accounts-service/protorepo/noted/accounts/v1"
 	"context"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/go-memdb"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -14,7 +16,8 @@ import (
 
 type GroupsAPISuite struct {
 	suite.Suite
-	srv *groupsAPI
+	groupSrv   *groupsAPI
+	accountSrv *accountsAPI
 }
 
 func TestGroupsService(t *testing.T) {
@@ -23,11 +26,21 @@ func TestGroupsService(t *testing.T) {
 
 func (s *GroupsAPISuite) SetupSuite() {
 	logger := newLoggerOrFail(s.T())
-	db := newGroupsDatabaseOrFail(s.T(), logger)
-	s.srv = &groupsAPI{
+	groupDB := newGroupsDatabaseOrFail(s.T(), logger)
+	memberDB := newMembersDatabaseOrFail(s.T(), logger)
+	accountDB := newAccountsDatabaseOrFail(s.T(), logger)
+
+	s.accountSrv = &accountsAPI{
 		auth:   auth.NewService(genKeyOrFail(s.T())),
 		logger: logger,
-		repo:   memory.NewGroupsRepository(db, logger),
+		repo:   memory.NewAccountsRepository(accountDB, logger),
+	}
+
+	s.groupSrv = &groupsAPI{
+		auth:       auth.NewService(genKeyOrFail(s.T())),
+		logger:     logger,
+		groupRepo:  memory.NewGroupsRepository(groupDB, logger),
+		memberRepo: memory.NewMembersRepository(memberDB, logger),
 	}
 }
 
@@ -42,11 +55,6 @@ func newGroupsDatabaseSchema() *memdb.DBSchema {
 						Unique:  true,
 						Indexer: &memdb.StringFieldIndex{Field: "ID"},
 					},
-					"owner_id": {
-						Name:    "owner_id",
-						Unique:  true,
-						Indexer: &memdb.StringFieldIndex{Field: "OwnerID"},
-					},
 					"name": {
 						Name:    "name",
 						Unique:  false,
@@ -57,7 +65,43 @@ func newGroupsDatabaseSchema() *memdb.DBSchema {
 						Unique:  false,
 						Indexer: &memdb.StringFieldIndex{Field: "Description"},
 					},
-					//TODO : Members and Notes sheme
+					"created_at": {
+						Name:    "created_at",
+						Unique:  false,
+						Indexer: &memdb.StringFieldIndex{Field: "CreatedAt"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func newMembersDatabaseSchema() *memdb.DBSchema {
+	return &memdb.DBSchema{
+		Tables: map[string]*memdb.TableSchema{
+			"member": {
+				Name: "member",
+				Indexes: map[string]*memdb.IndexSchema{
+					"id": {
+						Name:    "id",
+						Unique:  true,
+						Indexer: &memdb.StringFieldIndex{Field: "ID"},
+					},
+					"account_id": {
+						Name:    "account_id",
+						Unique:  false,
+						Indexer: &memdb.StringFieldIndex{Field: "Account"},
+					},
+					"group_id": {
+						Name:    "group_id",
+						Unique:  false,
+						Indexer: &memdb.StringFieldIndex{Field: "Group"},
+					},
+					"created_at": {
+						Name:    "created_at",
+						Unique:  false,
+						Indexer: &memdb.StringFieldIndex{Field: "CreatedAt"},
+					},
 				},
 			},
 		},
@@ -65,7 +109,282 @@ func newGroupsDatabaseSchema() *memdb.DBSchema {
 }
 
 func newGroupsDatabaseOrFail(t *testing.T, logger *zap.Logger) *memory.Database {
-	db, err := memory.NewDatabase(context.Background(), newGroupsDatabaseSchema(), logger)
-	require.NoError(t, err, "could not instantiate in-memory database")
-	return db
+	groupDB, err := memory.NewDatabase(context.Background(), newGroupsDatabaseSchema(), logger)
+	require.NoError(t, err, "could not instantiate in-memory group database")
+	return groupDB
+}
+
+func newMembersDatabaseOrFail(t *testing.T, logger *zap.Logger) *memory.Database {
+	memberDB, err := memory.NewDatabase(context.Background(), newMembersDatabaseSchema(), logger)
+	require.NoError(t, err, "could not instantiate in-memory member database")
+	return memberDB
+}
+
+func (s *GroupsAPISuite) TestCreateGroup() {
+	createAccountRes, err := s.accountSrv.CreateAccount(context.TODO(), &accountsv1.CreateAccountRequest{Email: "maxime.dodin@gmail.com", Password: "1234", Name: "Maxime"})
+	s.Require().NoError(err)
+
+	uid := uuid.MustParse(createAccountRes.Account.Id)
+
+	ctx, err := s.groupSrv.auth.ContextWithToken(context.TODO(), &auth.Token{UserID: uid})
+	s.Require().NoError(err)
+
+	createGroupRes, err := s.groupSrv.CreateGroup(ctx, &accountsv1.CreateGroupRequest{Description: "description", Name: "EIP"})
+	s.Require().NoError(err)
+
+	getGroupMemberRes, err := s.groupSrv.GetGroupMember(ctx, &accountsv1.GetGroupMemberRequest{GroupId: createGroupRes.Group.Id, AccountId: uid.String()})
+	s.Require().NoError(err)
+	s.Equal("admin", getGroupMemberRes.Member.Role)
+	s.Equal(uid.String(), getGroupMemberRes.Member.AccountId)
+}
+
+func (s *GroupsAPISuite) TestAddMembersToGroup() {
+	createAccountMaxRes, err := s.accountSrv.CreateAccount(context.TODO(), &accountsv1.CreateAccountRequest{Email: "maxime@gmail.com", Password: "1234", Name: "Maxime"})
+	s.Require().NoError(err)
+
+	createAccountGabiRes, err := s.accountSrv.CreateAccount(context.TODO(), &accountsv1.CreateAccountRequest{Email: "gabriel@gmail.com", Password: "1234", Name: "Gabriel"})
+	s.Require().NoError(err)
+
+	createAccountBalthiRes, err := s.accountSrv.CreateAccount(context.TODO(), &accountsv1.CreateAccountRequest{Email: "balthazard@gmail.com", Password: "1234", Name: "Balthazard"})
+	s.Require().NoError(err)
+
+	uid := uuid.MustParse(createAccountMaxRes.Account.Id)
+
+	ctx, err := s.groupSrv.auth.ContextWithToken(context.TODO(), &auth.Token{UserID: uid})
+	s.Require().NoError(err)
+
+	createGroupRes, err := s.groupSrv.CreateGroup(ctx, &accountsv1.CreateGroupRequest{Description: "description", Name: "EIP"})
+	s.Require().NoError(err)
+
+	_, err = s.groupSrv.AddGroupMember(ctx, &accountsv1.AddGroupMemberRequest{GroupId: createGroupRes.Group.Id, AccountId: createAccountBalthiRes.Account.Id})
+	s.Require().NoError(err)
+
+	_, err = s.groupSrv.AddGroupMember(ctx, &accountsv1.AddGroupMemberRequest{GroupId: createGroupRes.Group.Id, AccountId: createAccountGabiRes.Account.Id})
+	s.Require().NoError(err)
+
+	listGroupMemberResp, err := s.groupSrv.ListGroupMembers(ctx, &accountsv1.ListGroupMembersRequest{GroupId: createGroupRes.Group.Id})
+	s.Require().NoError(err)
+
+	s.Require().Equal(3, len(listGroupMemberResp.Members))
+}
+
+func (s *GroupsAPISuite) TestDeleteGroup() {
+	createAccountMaxRes, err := s.accountSrv.CreateAccount(context.TODO(), &accountsv1.CreateAccountRequest{Email: "maxime@gmail.com", Password: "1234", Name: "Maxime"})
+	s.Require().NoError(err)
+
+	createAccountGabiRes, err := s.accountSrv.CreateAccount(context.TODO(), &accountsv1.CreateAccountRequest{Email: "gabriel@gmail.com", Password: "1234", Name: "Gabriel"})
+	s.Require().NoError(err)
+
+	createAccountBalthiRes, err := s.accountSrv.CreateAccount(context.TODO(), &accountsv1.CreateAccountRequest{Email: "balthazard@gmail.com", Password: "1234", Name: "Balthazard"})
+	s.Require().NoError(err)
+
+	uid := uuid.MustParse(createAccountMaxRes.Account.Id)
+
+	ctx, err := s.groupSrv.auth.ContextWithToken(context.TODO(), &auth.Token{UserID: uid})
+	s.Require().NoError(err)
+
+	createGroupRes, err := s.groupSrv.CreateGroup(ctx, &accountsv1.CreateGroupRequest{Description: "description", Name: "EIP"})
+	s.Require().NoError(err)
+
+	_, err = s.groupSrv.AddGroupMember(ctx, &accountsv1.AddGroupMemberRequest{GroupId: createGroupRes.Group.Id, AccountId: createAccountBalthiRes.Account.Id})
+	s.Require().NoError(err)
+
+	_, err = s.groupSrv.AddGroupMember(ctx, &accountsv1.AddGroupMemberRequest{GroupId: createGroupRes.Group.Id, AccountId: createAccountGabiRes.Account.Id})
+	s.Require().NoError(err)
+
+	_, err = s.groupSrv.DeleteGroup(ctx, &accountsv1.DeleteGroupRequest{GroupId: createGroupRes.Group.Id})
+	s.Require().NoError(err)
+
+	listGroupMemberResp, err := s.groupSrv.ListGroupMembers(ctx, &accountsv1.ListGroupMembersRequest{GroupId: createGroupRes.Group.Id})
+	s.Require().NoError(err)
+
+	s.Require().Equal(0, len(listGroupMemberResp.Members))
+}
+
+func (s *GroupsAPISuite) TestLeaveGroupAsAdmin() {
+	createAccountMaxRes, err := s.accountSrv.CreateAccount(context.TODO(), &accountsv1.CreateAccountRequest{Email: "maxime@gmail.com", Password: "1234", Name: "Maxime"})
+	s.Require().NoError(err)
+
+	createAccountGabiRes, err := s.accountSrv.CreateAccount(context.TODO(), &accountsv1.CreateAccountRequest{Email: "gabriel@gmail.com", Password: "1234", Name: "Gabriel"})
+	s.Require().NoError(err)
+
+	createAccountBalthiRes, err := s.accountSrv.CreateAccount(context.TODO(), &accountsv1.CreateAccountRequest{Email: "balthazard@gmail.com", Password: "1234", Name: "Balthazard"})
+	s.Require().NoError(err)
+
+	uid := uuid.MustParse(createAccountMaxRes.Account.Id)
+
+	ctx, err := s.groupSrv.auth.ContextWithToken(context.TODO(), &auth.Token{UserID: uid})
+	s.Require().NoError(err)
+
+	createGroupRes, err := s.groupSrv.CreateGroup(ctx, &accountsv1.CreateGroupRequest{Description: "description", Name: "EIP"})
+	s.Require().NoError(err)
+
+	_, err = s.groupSrv.AddGroupMember(ctx, &accountsv1.AddGroupMemberRequest{GroupId: createGroupRes.Group.Id, AccountId: createAccountBalthiRes.Account.Id})
+	s.Require().NoError(err)
+
+	_, err = s.groupSrv.AddGroupMember(ctx, &accountsv1.AddGroupMemberRequest{GroupId: createGroupRes.Group.Id, AccountId: createAccountGabiRes.Account.Id})
+	s.Require().NoError(err)
+
+	_, err = s.groupSrv.RemoveGroupMember(ctx, &accountsv1.RemoveGroupMemberRequest{GroupId: createGroupRes.Group.Id, AccountId: createAccountMaxRes.Account.Id})
+	s.Require().NoError(err)
+
+	listGroupMemberResp, err := s.groupSrv.ListGroupMembers(ctx, &accountsv1.ListGroupMembersRequest{GroupId: createGroupRes.Group.Id})
+	s.Require().NoError(err)
+
+	isAdmin := false
+	s.Require().Equal(2, len(listGroupMemberResp.Members))
+	for _, gm := range listGroupMemberResp.Members {
+		if gm.Role == auth.RoleAdmin {
+			isAdmin = true
+		}
+	}
+	s.Require().True(isAdmin)
+}
+
+func (s *GroupsAPISuite) TestRemoveAdminMemberAsUser() {
+	createAccountMaxRes, err := s.accountSrv.CreateAccount(context.TODO(), &accountsv1.CreateAccountRequest{Email: "maxime@gmail.com", Password: "1234", Name: "Maxime"})
+	s.Require().NoError(err)
+
+	createAccountGabiRes, err := s.accountSrv.CreateAccount(context.TODO(), &accountsv1.CreateAccountRequest{Email: "gabriel@gmail.com", Password: "1234", Name: "Gabriel"})
+	s.Require().NoError(err)
+
+	createAccountBalthiRes, err := s.accountSrv.CreateAccount(context.TODO(), &accountsv1.CreateAccountRequest{Email: "balthazard@gmail.com", Password: "1234", Name: "Balthazard"})
+	s.Require().NoError(err)
+
+	uid := uuid.MustParse(createAccountMaxRes.Account.Id)
+
+	ctx, err := s.groupSrv.auth.ContextWithToken(context.TODO(), &auth.Token{UserID: uid})
+	s.Require().NoError(err)
+
+	createGroupRes, err := s.groupSrv.CreateGroup(ctx, &accountsv1.CreateGroupRequest{Description: "description", Name: "EIP"})
+	s.Require().NoError(err)
+
+	_, err = s.groupSrv.AddGroupMember(ctx, &accountsv1.AddGroupMemberRequest{GroupId: createGroupRes.Group.Id, AccountId: createAccountBalthiRes.Account.Id})
+	s.Require().NoError(err)
+
+	_, err = s.groupSrv.AddGroupMember(ctx, &accountsv1.AddGroupMemberRequest{GroupId: createGroupRes.Group.Id, AccountId: createAccountGabiRes.Account.Id})
+	s.Require().NoError(err)
+
+	uidBalthi := uuid.MustParse(createAccountBalthiRes.Account.Id)
+
+	ctxBalthi, err := s.groupSrv.auth.ContextWithToken(context.TODO(), &auth.Token{UserID: uidBalthi})
+	s.Require().NoError(err)
+
+	_, err = s.groupSrv.RemoveGroupMember(ctxBalthi, &accountsv1.RemoveGroupMemberRequest{GroupId: createGroupRes.Group.Id, AccountId: createAccountMaxRes.Account.Id})
+	s.Require().Error(err)
+
+	listGroupMemberResp, err := s.groupSrv.ListGroupMembers(ctx, &accountsv1.ListGroupMembersRequest{GroupId: createGroupRes.Group.Id})
+	s.Require().NoError(err)
+
+	isAdmin := false
+	s.Require().Equal(3, len(listGroupMemberResp.Members))
+	for _, gm := range listGroupMemberResp.Members {
+		if gm.Role == auth.RoleAdmin {
+			isAdmin = true
+		}
+	}
+	s.Require().True(isAdmin)
+}
+
+func (s *GroupsAPISuite) TestLeaveGroupAsUser() {
+	createAccountMaxRes, err := s.accountSrv.CreateAccount(context.TODO(), &accountsv1.CreateAccountRequest{Email: "maxime@gmail.com", Password: "1234", Name: "Maxime"})
+	s.Require().NoError(err)
+
+	createAccountGabiRes, err := s.accountSrv.CreateAccount(context.TODO(), &accountsv1.CreateAccountRequest{Email: "gabriel@gmail.com", Password: "1234", Name: "Gabriel"})
+	s.Require().NoError(err)
+
+	createAccountBalthiRes, err := s.accountSrv.CreateAccount(context.TODO(), &accountsv1.CreateAccountRequest{Email: "balthazard@gmail.com", Password: "1234", Name: "Balthazard"})
+	s.Require().NoError(err)
+
+	uid := uuid.MustParse(createAccountMaxRes.Account.Id)
+
+	ctx, err := s.groupSrv.auth.ContextWithToken(context.TODO(), &auth.Token{UserID: uid})
+	s.Require().NoError(err)
+
+	createGroupRes, err := s.groupSrv.CreateGroup(ctx, &accountsv1.CreateGroupRequest{Description: "description", Name: "EIP"})
+	s.Require().NoError(err)
+
+	_, err = s.groupSrv.AddGroupMember(ctx, &accountsv1.AddGroupMemberRequest{GroupId: createGroupRes.Group.Id, AccountId: createAccountBalthiRes.Account.Id})
+	s.Require().NoError(err)
+
+	_, err = s.groupSrv.AddGroupMember(ctx, &accountsv1.AddGroupMemberRequest{GroupId: createGroupRes.Group.Id, AccountId: createAccountGabiRes.Account.Id})
+	s.Require().NoError(err)
+
+	uidBalthi := uuid.MustParse(createAccountBalthiRes.Account.Id)
+
+	ctxBalthi, err := s.groupSrv.auth.ContextWithToken(context.TODO(), &auth.Token{UserID: uidBalthi})
+	s.Require().NoError(err)
+
+	_, err = s.groupSrv.RemoveGroupMember(ctxBalthi, &accountsv1.RemoveGroupMemberRequest{GroupId: createGroupRes.Group.Id, AccountId: createAccountBalthiRes.Account.Id})
+	s.Require().NoError(err)
+
+	listGroupMemberResp, err := s.groupSrv.ListGroupMembers(ctx, &accountsv1.ListGroupMembersRequest{GroupId: createGroupRes.Group.Id})
+	s.Require().NoError(err)
+
+	isAdmin := false
+	s.Require().Equal(2, len(listGroupMemberResp.Members))
+	for _, gm := range listGroupMemberResp.Members {
+		if gm.Role == auth.RoleAdmin {
+			isAdmin = true
+		}
+	}
+	s.Require().True(isAdmin)
+}
+
+func (s *GroupsAPISuite) TestListGroupIBelongTo() {
+	createAccountMaxRes, err := s.accountSrv.CreateAccount(context.TODO(), &accountsv1.CreateAccountRequest{Email: "maxime@gmail.com", Password: "1234", Name: "Maxime"})
+	s.Require().NoError(err)
+
+	createAccountGabiRes, err := s.accountSrv.CreateAccount(context.TODO(), &accountsv1.CreateAccountRequest{Email: "gabriel@gmail.com", Password: "1234", Name: "Gabriel"})
+	s.Require().NoError(err)
+
+	createAccountBalthiRes, err := s.accountSrv.CreateAccount(context.TODO(), &accountsv1.CreateAccountRequest{Email: "balthazard@gmail.com", Password: "1234", Name: "Balthazard"})
+	s.Require().NoError(err)
+
+	uid := uuid.MustParse(createAccountMaxRes.Account.Id)
+
+	uidGabi := uuid.MustParse(createAccountGabiRes.Account.Id)
+
+	ctxGabi, err := s.groupSrv.auth.ContextWithToken(context.TODO(), &auth.Token{UserID: uidGabi})
+	s.Require().NoError(err)
+
+	ctx, err := s.groupSrv.auth.ContextWithToken(context.TODO(), &auth.Token{UserID: uid})
+	s.Require().NoError(err)
+
+	createGroupRes1, err := s.groupSrv.CreateGroup(ctx, &accountsv1.CreateGroupRequest{Description: "description", Name: "Group1"})
+	s.Require().NoError(err)
+
+	_, err = s.groupSrv.AddGroupMember(ctx, &accountsv1.AddGroupMemberRequest{GroupId: createGroupRes1.Group.Id, AccountId: createAccountGabiRes.Account.Id})
+	s.Require().NoError(err)
+
+	_, err = s.groupSrv.AddGroupMember(ctx, &accountsv1.AddGroupMemberRequest{GroupId: createGroupRes1.Group.Id, AccountId: createAccountBalthiRes.Account.Id})
+	s.Require().NoError(err)
+
+	s.Require().NoError(err)
+
+	createGroupRes2, err := s.groupSrv.CreateGroup(ctx, &accountsv1.CreateGroupRequest{Description: "description", Name: "Group2"})
+	s.Require().NoError(err)
+
+	_, err = s.groupSrv.AddGroupMember(ctx, &accountsv1.AddGroupMemberRequest{GroupId: createGroupRes2.Group.Id, AccountId: createAccountGabiRes.Account.Id})
+	s.Require().NoError(err)
+
+	_, err = s.groupSrv.AddGroupMember(ctx, &accountsv1.AddGroupMemberRequest{GroupId: createGroupRes2.Group.Id, AccountId: createAccountBalthiRes.Account.Id})
+	s.Require().NoError(err)
+
+	_, err = s.groupSrv.CreateGroup(ctxGabi, &accountsv1.CreateGroupRequest{Description: "description", Name: "Group3"})
+	s.Require().NoError(err)
+
+	_, err = s.groupSrv.CreateGroup(ctxGabi, &accountsv1.CreateGroupRequest{Description: "description", Name: "Group4"})
+	s.Require().NoError(err)
+
+	_, err = s.groupSrv.CreateGroup(ctx, &accountsv1.CreateGroupRequest{Description: "description", Name: "Group5"})
+	s.Require().NoError(err)
+
+	listGroupRespGabi, err := s.groupSrv.ListGroups(ctx, &accountsv1.ListGroupsRequest{AccountId: createAccountGabiRes.Account.Id})
+	s.Require().NoError(err)
+	s.Require().Equal(4, len(listGroupRespGabi.Groups))
+
+	listGroupRespBalthi, err := s.groupSrv.ListGroups(ctx, &accountsv1.ListGroupsRequest{AccountId: createAccountBalthiRes.Account.Id})
+	s.Require().NoError(err)
+	s.Require().Equal(2, len(listGroupRespBalthi.Groups))
 }

--- a/members.go
+++ b/members.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	accountsv1 "accounts-service/protorepo/noted/accounts/v1"
+	"context"
+	"errors"
+)
+
+func (srv *groupsAPI) AddGroupMember(ctx context.Context, in *accountsv1.AddGroupMemberRequest) (*accountsv1.AddGroupMemberResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (srv *groupsAPI) RemoveGroupMember(ctx context.Context, in *accountsv1.RemoveGroupMemberRequest) (*accountsv1.RemoveGroupMemberResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (srv *groupsAPI) UpdateGroupMember(ctx context.Context, in *accountsv1.UpdateGroupMemberRequest) (*accountsv1.UpdateGroupMemberResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (srv *groupsAPI) GetGroupMember(ctx context.Context, in *accountsv1.GetGroupMemberRequest) (*accountsv1.GetGroupMemberResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (srv *groupsAPI) ListGroupMember(ctx context.Context, in *accountsv1.ListGroupMembersRequest) (*accountsv1.ListGroupMembersResponse, error) {
+	return nil, errors.New("not implemented")
+}

--- a/members.go
+++ b/members.go
@@ -7,7 +7,6 @@ import (
 	"accounts-service/validators"
 	"context"
 	"errors"
-	"time"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
@@ -28,7 +27,7 @@ func (srv *groupsAPI) AddGroupMember(ctx context.Context, in *accountsv1.AddGrou
 		return nil, status.Error(codes.InvalidArgument, "failed to get group from group_id")
 	}
 
-	payload := models.MemberPayload{AccountID: &in.AccountId, GroupID: &in.GroupId, Role: auth.RoleUser, CreatedAt: time.Now().UTC()}
+	payload := models.MemberPayload{AccountID: &in.AccountId, GroupID: &in.GroupId, Role: auth.RoleUser}
 	_, err = srv.memberRepo.Create(ctx, &payload)
 	if err != nil {
 		return nil, status.Error(codes.Internal, "failed to add member to group")
@@ -72,7 +71,7 @@ func (srv *groupsAPI) RemoveGroupMember(ctx context.Context, in *accountsv1.Remo
 	}
 
 	if memberDel.Role == auth.RoleAdmin {
-		err = srv.memberRepo.SetAdmin(ctx, &models.MemberFilter{GroupID: memberDel.GroupID})
+		_, err = srv.memberRepo.Update(ctx, &models.MemberFilter{GroupID: memberDel.GroupID}, &models.MemberPayload{GroupID: member.GroupID, AccountID: member.AccountID, Role: auth.RoleAdmin})
 		if err != nil {
 			return nil, statusFromModelError(err)
 		}

--- a/members.go
+++ b/members.go
@@ -1,27 +1,126 @@
 package main
 
 import (
+	"accounts-service/auth"
+	"accounts-service/models"
 	accountsv1 "accounts-service/protorepo/noted/accounts/v1"
+	"accounts-service/validators"
 	"context"
 	"errors"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
+// TODO: Add time-stamp from arrival in member models
+// TODO: internal token clarification with edouard/diego
+
 func (srv *groupsAPI) AddGroupMember(ctx context.Context, in *accountsv1.AddGroupMemberRequest) (*accountsv1.AddGroupMemberResponse, error) {
-	return nil, errors.New("not implemented")
+	err := validators.ValidateAddGroupMember(in)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "failed to validate add member request")
+	}
+
+	_, err = srv.groupRepo.Get(ctx, &models.OneGroupFilter{ID: in.GroupId})
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "failed to get group from group_id")
+	}
+
+	payload := models.MemberPayload{Account: &in.AccountId, Group: &in.GroupId, Role: auth.RoleUser}
+	_, err = srv.memberRepo.Create(ctx, &payload)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to add member to group")
+	}
+
+	return &accountsv1.AddGroupMemberResponse{}, nil
 }
 
+// TODO: If admin user is remove set a random new member as Admin
 func (srv *groupsAPI) RemoveGroupMember(ctx context.Context, in *accountsv1.RemoveGroupMemberRequest) (*accountsv1.RemoveGroupMemberResponse, error) {
-	return nil, errors.New("not implemented")
+	err := validators.ValidateRemoveGroupMember(in)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to validate remove member request")
+	}
+
+	token, err := srv.authenticate(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Unauthenticated, err.Error())
+	}
+
+	filter := models.MemberFilter{Account: &in.AccountId, Group: &in.GroupId}
+	member, err := srv.memberRepo.Get(ctx, &filter)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to get user from requested group")
+	}
+
+	if member.Role == auth.RoleUser && *member.Account != token.UserID.String() {
+		return nil, status.Error(codes.PermissionDenied, "user must be admin or delete himself")
+	}
+
+	err = srv.memberRepo.DeleteOne(ctx, &filter)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to remove member to group")
+	}
+
+	return &accountsv1.RemoveGroupMemberResponse{}, nil
 }
 
 func (srv *groupsAPI) UpdateGroupMember(ctx context.Context, in *accountsv1.UpdateGroupMemberRequest) (*accountsv1.UpdateGroupMemberResponse, error) {
+
 	return nil, errors.New("not implemented")
 }
 
 func (srv *groupsAPI) GetGroupMember(ctx context.Context, in *accountsv1.GetGroupMemberRequest) (*accountsv1.GetGroupMemberResponse, error) {
-	return nil, errors.New("not implemented")
+	err := validators.ValidateGetGroupMember(in)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	_, err = srv.authenticate(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Unauthenticated, err.Error())
+	}
+
+	filter := models.MemberFilter{Account: &in.AccountId, Group: &in.GroupId}
+	member, err := srv.memberRepo.Get(ctx, &filter)
+	if err != nil {
+		return nil, statusFromModelError(err)
+	}
+
+	if member == nil {
+		return nil, status.Error(codes.NotFound, "member not found")
+	}
+
+	groupMember := accountsv1.GroupMember{AccountId: *member.Account, Role: member.Role}
+	return &accountsv1.GetGroupMemberResponse{Member: &groupMember}, nil
 }
 
-func (srv *groupsAPI) ListGroupMember(ctx context.Context, in *accountsv1.ListGroupMembersRequest) (*accountsv1.ListGroupMembersResponse, error) {
-	return nil, errors.New("not implemented")
+func (srv *groupsAPI) ListGroupMembers(ctx context.Context, in *accountsv1.ListGroupMembersRequest) (*accountsv1.ListGroupMembersResponse, error) {
+	err := validators.ValidateListGroupMember(in)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to remove member to group")
+	}
+
+	_, err = srv.authenticate(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Unauthenticated, err.Error())
+	}
+
+	filter := models.MemberFilter{Group: &in.GroupId}
+	members, err := srv.memberRepo.List(ctx, &filter)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to remove member to group")
+	}
+
+	var groupMembers []*accountsv1.GroupMember
+	for _, member := range members {
+		groupMember := &accountsv1.GroupMember{AccountId: *member.Account, Role: member.Role}
+		if err != nil {
+			srv.logger.Error("failed to decode member", zap.Error(err))
+		}
+		groupMembers = append(groupMembers, groupMember)
+	}
+
+	return &accountsv1.ListGroupMembersResponse{Members: groupMembers}, nil
 }

--- a/models/groups.go
+++ b/models/groups.go
@@ -2,17 +2,20 @@ package models
 
 import (
 	"context"
+	"time"
 )
 
 type Group struct {
-	ID          string  `json:"id" bson:"_id,omitempty"`
-	Name        *string `json:"name" bson:"name,omitempty"`
-	Description *string `json:"description" bson:"description,omitempty"`
+	ID          string    `json:"id" bson:"_id,omitempty"`
+	Name        *string   `json:"name" bson:"name,omitempty"`
+	Description *string   `json:"description" bson:"description,omitempty"`
+	CreatedAt   time.Time `json:"created_at" bson:"created_at,omitempty"`
 }
 
 type GroupPayload struct {
-	Name        *string `json:"name" bson:"name,omitempty"`
-	Description *string `json:"description" bson:"description,omitempty"`
+	Name        *string   `json:"name" bson:"name,omitempty"`
+	Description *string   `json:"description" bson:"description,omitempty"`
+	CreatedAt   time.Time `json:"created_at" bson:"created_at,omitempty"`
 }
 
 type OneGroupFilter struct {

--- a/models/groups.go
+++ b/models/groups.go
@@ -5,27 +5,18 @@ import (
 )
 
 type Group struct {
-	ID          string         `json:"id" bson:"_id,omitempty"`
-	Name        *string        `json:"name" bson:"name,omitempty"`
-	OwnerID     string         `json:"owner_id" bson:"owner_id,omitempty"`
-	Description *string        `json:"description" bson:"description,omitempty"`
-	Members     *[]GroupMember `json:"members" bson:"members,omitempty"`
+	ID          string  `json:"id" bson:"_id,omitempty"`
+	Name        *string `json:"name" bson:"name,omitempty"`
+	Description *string `json:"description" bson:"description,omitempty"`
 }
 
 type GroupPayload struct {
-	Name        *string        `json:"name" bson:"name,omitempty"`
-	Description *string        `json:"description" bson:"description,omitempty"`
-	OwnerID     string         `json:"owner_id" bson:"owner_id,omitempty"`
-	Members     *[]GroupMember `json:"members" bson:"members,omitempty"`
-}
-
-type GroupMember struct {
-	ID string `json:"account_id" bson:"account_id,omitempty"`
+	Name        *string `json:"name" bson:"name,omitempty"`
+	Description *string `json:"description" bson:"description,omitempty"`
 }
 
 type OneGroupFilter struct {
-	ID      string `json:"id" bson:"_id,omitempty"`
-	OwnerID string `json:"owner_id" bson:"owner_id,omitempty"`
+	ID string `json:"id" bson:"_id,omitempty"`
 }
 
 type ManyGroupsFilter struct {

--- a/models/groups.go
+++ b/models/groups.go
@@ -13,9 +13,8 @@ type Group struct {
 }
 
 type GroupPayload struct {
-	Name        *string   `json:"name" bson:"name,omitempty"`
-	Description *string   `json:"description" bson:"description,omitempty"`
-	CreatedAt   time.Time `json:"created_at" bson:"created_at,omitempty"`
+	Name        *string `json:"name" bson:"name,omitempty"`
+	Description *string `json:"description" bson:"description,omitempty"`
 }
 
 type OneGroupFilter struct {

--- a/models/members.go
+++ b/models/members.go
@@ -5,31 +5,33 @@ import (
 )
 
 type Member struct {
-	ID      string  `json:"member_id" bson:"member_id,omitempty"`
-	Account string  `json:"account_id" bson:"account_id,omitempty"`
-	Group   string  `json:"group_id" bson:"group_id,omitempty"`
-	Role    *string `json:"role" bson:"role,omitempty"`
+	ID      string  `json:"_id" bson:"_id,omitempty"`
+	Account *string `json:"account_id" bson:"account_id,omitempty"`
+	Group   *string `json:"group_id" bson:"group_id,omitempty"`
+	Role    string  `json:"role" bson:"role,omitempty"`
 }
 
 type MemberPayload struct {
-	Account string  `json:"account_id" bson:"account_id,omitempty"`
-	Group   string  `json:"group_id" bson:"group_id,omitempty"`
-	Role    *string `json:"role" bson:"role,omitempty"`
+	Account *string `json:"account_id" bson:"account_id,omitempty"`
+	Group   *string `json:"group_id" bson:"group_id,omitempty"`
+	Role    string  `json:"role" bson:"role,omitempty"`
 }
 
 type MemberFilter struct {
-	Account string `json:"account_id" bson:"account_id,omitempty"`
-	Group   string `json:"group_id" bson:"group_id,omitempty"`
+	Account *string `json:"account_id" bson:"account_id,omitempty"`
+	Group   *string `json:"group_id" bson:"group_id,omitempty"`
 }
 
 type MembersRepository interface {
 	Create(ctx context.Context, filter *MemberPayload) (*Member, error)
 
-	Delete(ctx context.Context, filter *MemberFilter) error
+	DeleteOne(ctx context.Context, filter *MemberFilter) error
+
+	DeleteMany(ctx context.Context, filter *MemberFilter) error
 
 	Get(ctx context.Context, filter *MemberFilter) (*Member, error)
 
 	Update(ctx context.Context, filter *MemberFilter, account *MemberPayload) (*Member, error)
 
-	List(ctx context.Context, filter *MemberFilter, pagination *Pagination) ([]Member, error)
+	List(ctx context.Context, filter *MemberFilter) ([]Member, error)
 }

--- a/models/members.go
+++ b/models/members.go
@@ -7,22 +7,22 @@ import (
 
 type Member struct {
 	ID        string    `json:"_id" bson:"_id,omitempty"`
-	Account   *string   `json:"account_id" bson:"account_id,omitempty"`
-	Group     *string   `json:"group_id" bson:"group_id,omitempty"`
+	AccountID *string   `json:"account_id" bson:"account_id,omitempty"`
+	GroupID   *string   `json:"group_id" bson:"group_id,omitempty"`
 	Role      string    `json:"role" bson:"role,omitempty"`
 	CreatedAt time.Time `json:"created_at" bson:"created_at,omitempty"`
 }
 
 type MemberPayload struct {
-	Account   *string   `json:"account_id" bson:"account_id,omitempty"`
-	Group     *string   `json:"group_id" bson:"group_id,omitempty"`
+	AccountID *string   `json:"account_id" bson:"account_id,omitempty"`
+	GroupID   *string   `json:"group_id" bson:"group_id,omitempty"`
 	Role      string    `json:"role" bson:"role,omitempty"`
 	CreatedAt time.Time `json:"created_at" bson:"created_at,omitempty"`
 }
 
 type MemberFilter struct {
-	Account *string `json:"account_id" bson:"account_id,omitempty"`
-	Group   *string `json:"group_id" bson:"group_id,omitempty"`
+	AccountID *string `json:"account_id" bson:"account_id,omitempty"`
+	GroupID   *string `json:"group_id" bson:"group_id,omitempty"`
 }
 
 type MembersRepository interface {

--- a/models/members.go
+++ b/models/members.go
@@ -1,0 +1,35 @@
+package models
+
+import (
+	"context"
+)
+
+type Member struct {
+	ID      string  `json:"member_id" bson:"member_id,omitempty"`
+	Account string  `json:"account_id" bson:"account_id,omitempty"`
+	Group   string  `json:"group_id" bson:"group_id,omitempty"`
+	Role    *string `json:"role" bson:"role,omitempty"`
+}
+
+type MemberPayload struct {
+	Account string  `json:"account_id" bson:"account_id,omitempty"`
+	Group   string  `json:"group_id" bson:"group_id,omitempty"`
+	Role    *string `json:"role" bson:"role,omitempty"`
+}
+
+type MemberFilter struct {
+	Account string `json:"account_id" bson:"account_id,omitempty"`
+	Group   string `json:"group_id" bson:"group_id,omitempty"`
+}
+
+type MembersRepository interface {
+	Create(ctx context.Context, filter *MemberPayload) (*Member, error)
+
+	Delete(ctx context.Context, filter *MemberFilter) error
+
+	Get(ctx context.Context, filter *MemberFilter) (*Member, error)
+
+	Update(ctx context.Context, filter *MemberFilter, account *MemberPayload) (*Member, error)
+
+	List(ctx context.Context, filter *MemberFilter, pagination *Pagination) ([]Member, error)
+}

--- a/models/members.go
+++ b/models/members.go
@@ -2,19 +2,22 @@ package models
 
 import (
 	"context"
+	"time"
 )
 
 type Member struct {
-	ID      string  `json:"_id" bson:"_id,omitempty"`
-	Account *string `json:"account_id" bson:"account_id,omitempty"`
-	Group   *string `json:"group_id" bson:"group_id,omitempty"`
-	Role    string  `json:"role" bson:"role,omitempty"`
+	ID        string    `json:"_id" bson:"_id,omitempty"`
+	Account   *string   `json:"account_id" bson:"account_id,omitempty"`
+	Group     *string   `json:"group_id" bson:"group_id,omitempty"`
+	Role      string    `json:"role" bson:"role,omitempty"`
+	CreatedAt time.Time `json:"created_at" bson:"created_at,omitempty"`
 }
 
 type MemberPayload struct {
-	Account *string `json:"account_id" bson:"account_id,omitempty"`
-	Group   *string `json:"group_id" bson:"group_id,omitempty"`
-	Role    string  `json:"role" bson:"role,omitempty"`
+	Account   *string   `json:"account_id" bson:"account_id,omitempty"`
+	Group     *string   `json:"group_id" bson:"group_id,omitempty"`
+	Role      string    `json:"role" bson:"role,omitempty"`
+	CreatedAt time.Time `json:"created_at" bson:"created_at,omitempty"`
 }
 
 type MemberFilter struct {

--- a/models/members.go
+++ b/models/members.go
@@ -14,10 +14,9 @@ type Member struct {
 }
 
 type MemberPayload struct {
-	AccountID *string   `json:"account_id" bson:"account_id,omitempty"`
-	GroupID   *string   `json:"group_id" bson:"group_id,omitempty"`
-	Role      string    `json:"role" bson:"role,omitempty"`
-	CreatedAt time.Time `json:"created_at" bson:"created_at,omitempty"`
+	AccountID *string `json:"account_id" bson:"account_id,omitempty"`
+	GroupID   *string `json:"group_id" bson:"group_id,omitempty"`
+	Role      string  `json:"role" bson:"role,omitempty"`
 }
 
 type MemberFilter struct {
@@ -38,5 +37,5 @@ type MembersRepository interface {
 
 	List(ctx context.Context, filter *MemberFilter) ([]Member, error)
 
-	SetAdmin(ctx context.Context, filter *MemberFilter) error
+	// SetAdmin(ctx context.Context, filter *MemberFilter) error
 }

--- a/models/members.go
+++ b/models/members.go
@@ -28,7 +28,7 @@ type MemberFilter struct {
 type MembersRepository interface {
 	Create(ctx context.Context, filter *MemberPayload) (*Member, error)
 
-	DeleteOne(ctx context.Context, filter *MemberFilter) error
+	DeleteOne(ctx context.Context, filter *MemberFilter) (*Member, error)
 
 	DeleteMany(ctx context.Context, filter *MemberFilter) error
 
@@ -37,4 +37,6 @@ type MembersRepository interface {
 	Update(ctx context.Context, filter *MemberFilter, account *MemberPayload) (*Member, error)
 
 	List(ctx context.Context, filter *MemberFilter) ([]Member, error)
+
+	SetAdmin(ctx context.Context, filter *MemberFilter) error
 }

--- a/models/memory/groups.go
+++ b/models/memory/groups.go
@@ -34,8 +34,6 @@ func (srv *groupsRepository) Create(ctx context.Context, payload *models.GroupPa
 		ID:          id.String(),
 		Name:        payload.Name,
 		Description: payload.Description,
-		OwnerID:     payload.OwnerID,
-		Members:     payload.Members,
 	}
 
 	err = txn.Insert("group", &group)

--- a/models/memory/groups.go
+++ b/models/memory/groups.go
@@ -36,7 +36,6 @@ func (srv *groupsRepository) Create(ctx context.Context, payload *models.GroupPa
 		ID:          id.String(),
 		Name:        payload.Name,
 		Description: payload.Description,
-		CreatedAt:   payload.CreatedAt,
 	}
 
 	err = txn.Insert("group", &group)
@@ -88,7 +87,7 @@ func (srv *groupsRepository) Update(ctx context.Context, filter *models.OneGroup
 	txn := srv.groupDB.DB.Txn(true)
 	defer txn.Abort()
 
-	newGroup := models.Group{ID: filter.ID, Description: group.Description, Name: group.Name, CreatedAt: group.CreatedAt}
+	newGroup := models.Group{ID: filter.ID, Description: group.Description, Name: group.Name}
 	err := txn.Insert("group", &newGroup)
 	if err != nil {
 		if errors.Is(err, memdb.ErrNotFound) {

--- a/models/memory/members.go
+++ b/models/memory/members.go
@@ -1,0 +1,185 @@
+package memory
+
+import (
+	"accounts-service/auth"
+	"accounts-service/models"
+	"errors"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-memdb"
+	"go.uber.org/zap"
+	"golang.org/x/net/context"
+)
+
+type membersRepository struct {
+	logger    *zap.Logger
+	membersDB *Database
+}
+
+func NewMembersRepository(membersDB *Database, logger *zap.Logger) models.MembersRepository {
+	return &membersRepository{
+		logger:    logger.Named("memory").Named("members"),
+		membersDB: membersDB,
+	}
+}
+
+func (srv *membersRepository) Create(ctx context.Context, payload *models.MemberPayload) (*models.Member, error) {
+	txn := srv.membersDB.DB.Txn(true)
+	defer txn.Abort()
+
+	id, err := uuid.NewRandom()
+	if err != nil {
+		srv.logger.Error("failed to generate new random uuid", zap.Error(err))
+		return nil, err
+	}
+
+	member := models.Member{
+		ID:      id.String(),
+		Group:   payload.Group,
+		Account: payload.Account,
+		Role:    payload.Role,
+	}
+
+	err = txn.Insert("member", &member)
+	if err != nil {
+		srv.logger.Error("insert member failed", zap.Error(err), zap.String("account_id", *member.Account))
+		return nil, err
+	}
+
+	txn.Commit()
+	return &member, nil
+}
+
+func (srv *membersRepository) DeleteOne(ctx context.Context, filter *models.MemberFilter) (*models.Member, error) {
+	txn := srv.membersDB.DB.Txn(true)
+	defer txn.Abort()
+
+	it, err := txn.Get("member", "group_id", *filter.Group)
+
+	if err != nil {
+		if errors.Is(err, memdb.ErrNotFound) {
+			return nil, models.ErrNotFound
+		}
+		srv.logger.Error("unable to get member", zap.Error(err))
+		return nil, err
+	}
+
+	memberDel := &models.Member{}
+	for obj := it.Next(); obj != nil; obj = it.Next() {
+		memberDel = obj.(*models.Member)
+		if *memberDel.Account == *filter.Account {
+			err = txn.Delete("member", models.Member{ID: memberDel.ID})
+			if err != nil {
+				srv.logger.Error("unable to delete member from object", zap.Error(err))
+				return nil, err
+			}
+			break
+		}
+	}
+
+	txn.Commit()
+	return memberDel, nil
+}
+
+func (srv *membersRepository) DeleteMany(ctx context.Context, filter *models.MemberFilter) error {
+	txn := srv.membersDB.DB.Txn(true)
+	defer txn.Abort()
+
+	it, err := txn.Get("member", "group_id", *filter.Group)
+
+	if err != nil {
+		if errors.Is(err, memdb.ErrNotFound) {
+			return models.ErrNotFound
+		}
+		srv.logger.Error("unable to get members", zap.Error(err))
+		return err
+	}
+
+	for obj := it.Next(); obj != nil; obj = it.Next() {
+		err = txn.Delete("member", models.Member{ID: obj.(*models.Member).ID})
+		if err != nil {
+			srv.logger.Error("unable to delete member from object", zap.Error(err))
+			return err
+		}
+	}
+	txn.Commit()
+	return nil
+}
+
+func (srv *membersRepository) Get(ctx context.Context, filter *models.MemberFilter) (*models.Member, error) {
+	txn := srv.membersDB.DB.Txn(false)
+	defer txn.Abort()
+
+	it, err := txn.Get("member", "account_id", *filter.Account)
+	if err != nil {
+		if errors.Is(err, memdb.ErrNotFound) {
+			return nil, err
+		}
+		srv.logger.Error("unable to query member", zap.Error(err))
+		return nil, err
+	}
+
+	for obj := it.Next(); obj != nil; obj = it.Next() {
+		member := obj.(*models.Member)
+		if *member.Group == *filter.Group {
+			return member, nil
+		}
+	}
+	return nil, models.ErrNotFound
+}
+
+func (srv *membersRepository) Update(ctx context.Context, filter *models.MemberFilter, member *models.MemberPayload) (*models.Member, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (srv *membersRepository) List(ctx context.Context, filter *models.MemberFilter) ([]models.Member, error) {
+	var members []models.Member
+	var err error
+	var it memdb.ResultIterator
+
+	txn := srv.membersDB.DB.Txn(false)
+
+	if filter.Group == nil || *filter.Group == "" {
+		it, err = txn.Get("member", "account_id", *filter.Account)
+	} else {
+		it, err = txn.Get("member", "group_id", *filter.Group)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	for obj := it.Next(); obj != nil; obj = it.Next() {
+		newMember := models.Member{ID: obj.(*models.Member).ID, Group: obj.(*models.Member).Group, Account: obj.(*models.Member).Account, Role: obj.(*models.Member).Role}
+		members = append(members, newMember)
+	}
+
+	return members, nil
+}
+
+func (srv *membersRepository) SetAdmin(ctx context.Context, filter *models.MemberFilter) error {
+	txn := srv.membersDB.DB.Txn(true)
+	defer txn.Abort()
+
+	it, err := txn.Get("member", "group_id", *filter.Group)
+
+	if err != nil {
+		if errors.Is(err, memdb.ErrNotFound) {
+			return models.ErrNotFound
+		}
+		srv.logger.Error("unable to get members", zap.Error(err))
+		return err
+	}
+
+	for obj := it.Next(); obj != nil; obj = it.Next() {
+		newAdmin := obj.(*models.Member)
+		err = txn.Insert("member", &models.Member{ID: newAdmin.ID, Account: newAdmin.Account, Group: newAdmin.Group, Role: auth.RoleAdmin})
+		if err != nil {
+			srv.logger.Error("unable to update member from object", zap.Error(err))
+			return err
+		} else {
+			break
+		}
+	}
+	txn.Commit()
+	return nil
+}

--- a/models/mongo/groups.go
+++ b/models/mongo/groups.go
@@ -6,6 +6,7 @@ import (
 	"accounts-service/models"
 	"context"
 	"errors"
+	"time"
 
 	"github.com/google/uuid"
 	"go.mongodb.org/mongo-driver/bson"
@@ -35,7 +36,7 @@ func (srv *groupsRepository) Create(ctx context.Context, payload *models.GroupPa
 		return nil, err
 	}
 
-	group := models.Group{ID: id.String(), Name: payload.Name, Description: payload.Description, CreatedAt: payload.CreatedAt}
+	group := models.Group{ID: id.String(), Name: payload.Name, Description: payload.Description, CreatedAt: time.Now().UTC()}
 
 	_, err = srv.coll.InsertOne(ctx, group)
 	if err != nil {

--- a/models/mongo/groups.go
+++ b/models/mongo/groups.go
@@ -35,7 +35,7 @@ func (srv *groupsRepository) Create(ctx context.Context, payload *models.GroupPa
 		return nil, err
 	}
 
-	group := models.Group{ID: id.String(), Name: payload.Name, Description: payload.Description}
+	group := models.Group{ID: id.String(), Name: payload.Name, Description: payload.Description, CreatedAt: payload.CreatedAt}
 
 	_, err = srv.coll.InsertOne(ctx, group)
 	if err != nil {

--- a/models/mongo/groups.go
+++ b/models/mongo/groups.go
@@ -35,7 +35,7 @@ func (srv *groupsRepository) Create(ctx context.Context, payload *models.GroupPa
 		return nil, err
 	}
 
-	group := models.Group{ID: id.String(), Name: payload.Name, Members: payload.Members, Description: payload.Description, OwnerID: payload.OwnerID}
+	group := models.Group{ID: id.String(), Name: payload.Name, Description: payload.Description}
 
 	_, err = srv.coll.InsertOne(ctx, group)
 	if err != nil {

--- a/models/mongo/members.go
+++ b/models/mongo/members.go
@@ -2,8 +2,12 @@ package mongo
 
 import (
 	"accounts-service/models"
+	"errors"
 
+	"github.com/google/uuid"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.uber.org/zap"
 	"golang.org/x/net/context"
 )
@@ -15,29 +19,110 @@ type membersRepository struct {
 }
 
 func NewMembersRepository(db *mongo.Database, logger *zap.Logger) models.MembersRepository {
-	return &membersRepository{
+	rep := &membersRepository{
 		logger: logger.Named("mongo").Named("members"),
 		db:     db,
 		coll:   db.Collection("members"),
 	}
+
+	_, err := rep.coll.Indexes().CreateOne(
+		context.Background(),
+		mongo.IndexModel{
+			Keys:    bson.D{{Key: "account_id", Value: 1}, {Key: "group_id", Value: 1}},
+			Options: options.Index().SetUnique(true),
+		},
+	)
+	if err != nil {
+		rep.logger.Error("index creation failed", zap.Error(err))
+	}
+	return rep
 }
 
-func (srv *membersRepository) Create(ctx context.Context, member *models.MemberPayload) (*models.Member, error) {
-	return &models.Member{}, nil
+func (srv *membersRepository) Create(ctx context.Context, payload *models.MemberPayload) (*models.Member, error) {
+	id, err := uuid.NewRandom()
+	if err != nil {
+		srv.logger.Error("failed to generate new random uuid", zap.Error(err))
+		return nil, err
+	}
+
+	member := models.Member{ID: id.String(), Account: payload.Account, Group: payload.Group, Role: payload.Role}
+
+	_, err = srv.coll.InsertOne(ctx, member)
+	if err != nil {
+		srv.logger.Error("insert failed", zap.Error(err), zap.String("group_id", *member.Group))
+		return nil, err
+	}
+
+	return &member, nil
 }
 
-func (srv *membersRepository) Delete(ctx context.Context, filter *models.MemberFilter) error {
+func (srv *membersRepository) DeleteOne(ctx context.Context, filter *models.MemberFilter) error {
+	delete, err := srv.coll.DeleteOne(ctx, filter)
+	if err != nil {
+		srv.logger.Error("delete one failed", zap.Error(err))
+		return err
+	}
+	if delete.DeletedCount == 0 {
+		return models.ErrNotFound
+	}
+
+	return nil
+}
+
+func (srv *membersRepository) DeleteMany(ctx context.Context, filter *models.MemberFilter) error {
+	delete, err := srv.coll.DeleteMany(ctx, filter)
+	if err != nil {
+		srv.logger.Error("delete many failed", zap.Error(err))
+		return err
+	}
+	if delete.DeletedCount == 0 {
+		return models.ErrNotFound
+	}
 	return nil
 }
 
 func (srv *membersRepository) Get(ctx context.Context, filter *models.MemberFilter) (*models.Member, error) {
-	return &models.Member{}, nil
+	var member models.Member
+
+	err := srv.coll.FindOne(ctx, filter).Decode(&member)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, models.ErrNotFound
+		}
+		srv.logger.Error("query failed", zap.Error(err))
+		return nil, err
+	}
+
+	return &member, nil
 }
 
 func (srv *membersRepository) Update(ctx context.Context, filter *models.MemberFilter, member *models.MemberPayload) (*models.Member, error) {
 	return &models.Member{}, nil
 }
 
-func (srv *membersRepository) List(ctx context.Context, filter *models.MemberFilter, pagination *models.Pagination) ([]models.Member, error) {
-	return []models.Member{}, nil
+func (srv *membersRepository) List(ctx context.Context, filter *models.MemberFilter) ([]models.Member, error) {
+	var members []models.Member
+
+	// opt := options.FindOptions{
+	// 	Limit: &pagination.Limit,
+	// 	Skip:  &pagination.Offset,
+	// }
+
+	cursor, err := srv.coll.Find(ctx, &filter)
+	if err != nil {
+		srv.logger.Error("mongo find members query failed", zap.Error(err))
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	for cursor.Next(ctx) {
+		var member models.Member
+		err := cursor.Decode(&member)
+		if err != nil {
+			srv.logger.Error("failed to decode mongo cursor result", zap.Error(err))
+		}
+		members = append(members, member)
+	}
+
+	return members, nil
 }

--- a/models/mongo/members.go
+++ b/models/mongo/members.go
@@ -1,0 +1,43 @@
+package mongo
+
+import (
+	"accounts-service/models"
+
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.uber.org/zap"
+	"golang.org/x/net/context"
+)
+
+type membersRepository struct {
+	logger *zap.Logger
+	db     *mongo.Database
+	coll   *mongo.Collection
+}
+
+func NewMembersRepository(db *mongo.Database, logger *zap.Logger) models.MembersRepository {
+	return &membersRepository{
+		logger: logger.Named("mongo").Named("members"),
+		db:     db,
+		coll:   db.Collection("members"),
+	}
+}
+
+func (srv *membersRepository) Create(ctx context.Context, member *models.MemberPayload) (*models.Member, error) {
+	return &models.Member{}, nil
+}
+
+func (srv *membersRepository) Delete(ctx context.Context, filter *models.MemberFilter) error {
+	return nil
+}
+
+func (srv *membersRepository) Get(ctx context.Context, filter *models.MemberFilter) (*models.Member, error) {
+	return &models.Member{}, nil
+}
+
+func (srv *membersRepository) Update(ctx context.Context, filter *models.MemberFilter, member *models.MemberPayload) (*models.Member, error) {
+	return &models.Member{}, nil
+}
+
+func (srv *membersRepository) List(ctx context.Context, filter *models.MemberFilter, pagination *models.Pagination) ([]models.Member, error) {
+	return []models.Member{}, nil
+}

--- a/models/mongo/members.go
+++ b/models/mongo/members.go
@@ -46,11 +46,11 @@ func (srv *membersRepository) Create(ctx context.Context, payload *models.Member
 		return nil, err
 	}
 
-	member := models.Member{ID: id.String(), Account: payload.Account, Group: payload.Group, Role: payload.Role, CreatedAt: payload.CreatedAt}
+	member := models.Member{ID: id.String(), AccountID: payload.AccountID, GroupID: payload.GroupID, Role: payload.Role, CreatedAt: payload.CreatedAt}
 
 	_, err = srv.coll.InsertOne(ctx, member)
 	if err != nil {
-		srv.logger.Error("insert failed", zap.Error(err), zap.String("group_id", *member.Group))
+		srv.logger.Error("insert failed", zap.Error(err), zap.String("group_id", *member.GroupID))
 		return nil, err
 	}
 

--- a/server.go
+++ b/server.go
@@ -30,6 +30,7 @@ type server struct {
 
 	accountsRepository models.AccountsRepository
 	groupsRepository   models.GroupsRepository
+	membersRepository  models.MembersRepository
 
 	accountsService accountsv1.AccountsAPIServer
 	groupsService   accountsv1.GroupsAPIServer
@@ -115,6 +116,7 @@ func (s *server) initRepositories() {
 	must(err, "could not instantiate mongo database")
 	s.accountsRepository = mongo.NewAccountsRepository(s.mongoDB.DB, s.logger)
 	s.groupsRepository = mongo.NewGroupsRepository(s.mongoDB.DB, s.logger)
+	s.membersRepository = mongo.NewMembersRepository(s.mongoDB.DB, s.logger)
 }
 
 func (s *server) initAccountsService() {
@@ -127,9 +129,10 @@ func (s *server) initAccountsService() {
 
 func (s *server) initGroupsService() {
 	s.groupsService = &groupsAPI{
-		auth:   s.authService,
-		logger: s.logger,
-		repo:   s.groupsRepository,
+		auth:       s.authService,
+		logger:     s.logger,
+		groupRepo:  s.groupsRepository,
+		memberRepo: s.membersRepository,
 	}
 }
 

--- a/validators/accounts.go
+++ b/validators/accounts.go
@@ -41,3 +41,5 @@ func ValidateAuthenticateRequest(in *accountsv1.AuthenticateRequest) error {
 		validation.Field(&in.Password, validation.Required, validation.Length(4, 20)),
 	)
 }
+
+func ValidateListRequest(in *accountsv1.ListAccountsRequest) error { return nil }

--- a/validators/accounts.go
+++ b/validators/accounts.go
@@ -42,4 +42,14 @@ func ValidateAuthenticateRequest(in *accountsv1.AuthenticateRequest) error {
 	)
 }
 
-func ValidateListRequest(in *accountsv1.ListAccountsRequest) error { return nil }
+func ValidateListRequest(in *accountsv1.ListAccountsRequest) error {
+	err := validation.Validate(in.Limit, validation.When(in.Limit != 0, validation.Required), validation.Min(0))
+	if err != nil {
+		return err
+	}
+	err = validation.Validate(in.Offset, validation.When(in.Offset != 0, validation.Required), validation.Min(0))
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/validators/groups.go
+++ b/validators/groups.go
@@ -18,3 +18,7 @@ func ValidateUpdatedGroupRequest(in *accountsv1.UpdateGroupRequest) error {
 		validation.Field(&in.Group.Id, validation.Required, is.UUID),
 	)
 }
+
+func ValidateListGroups(in *accountsv1.ListGroupsRequest) error {
+	return validation.Validate(&in.AccountId, validation.Required, is.UUID)
+}

--- a/validators/groups.go
+++ b/validators/groups.go
@@ -9,13 +9,12 @@ import (
 
 func ValidateDeleteGroupRequest(in *accountsv1.DeleteGroupRequest) error {
 	return validation.ValidateStruct(in,
-		validation.Field(&in.Id, validation.Required, is.UUID),
+		validation.Field(&in.GroupId, validation.Required, is.UUID),
 	)
 }
 
 func ValidateUpdatedGroupRequest(in *accountsv1.UpdateGroupRequest) error {
 	return validation.ValidateStruct(in.Group,
 		validation.Field(&in.Group.Id, validation.Required, is.UUID),
-		validation.Field(&in.Group.OwnerId, validation.Required, is.UUID),
 	)
 }

--- a/validators/groups.go
+++ b/validators/groups.go
@@ -22,3 +22,7 @@ func ValidateUpdatedGroupRequest(in *accountsv1.UpdateGroupRequest) error {
 func ValidateListGroups(in *accountsv1.ListGroupsRequest) error {
 	return validation.Validate(&in.AccountId, validation.Required, is.UUID)
 }
+
+func ValidateGetGroup(in *accountsv1.GetGroupRequest) error {
+	return validation.Validate(&in.GroupId, validation.Required, is.UUID)
+}

--- a/validators/members.go
+++ b/validators/members.go
@@ -1,0 +1,42 @@
+package validators
+
+import (
+	accountsv1 "accounts-service/protorepo/noted/accounts/v1"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/go-ozzo/ozzo-validation/v4/is"
+)
+
+func ValidateAddGroupMember(in *accountsv1.AddGroupMemberRequest) error {
+	return validation.ValidateStruct(in,
+		validation.Field(&in.GroupId, validation.Required, is.UUID),
+		validation.Field(&in.AccountId, validation.Required, is.UUID),
+	)
+}
+
+func ValidateRemoveGroupMember(in *accountsv1.RemoveGroupMemberRequest) error {
+	return validation.ValidateStruct(in,
+		validation.Field(&in.GroupId, validation.Required, is.UUID),
+		validation.Field(&in.AccountId, validation.Required, is.UUID),
+	)
+}
+
+func ValidateUpdateGroupMember(in *accountsv1.UpdateGroupMemberRequest) error {
+	return validation.ValidateStruct(in,
+		validation.Field(&in.GroupId, validation.Required, is.UUID),
+		validation.Field(&in.AccountId, validation.Required, is.UUID),
+	)
+}
+
+func ValidateListGroupMember(in *accountsv1.ListGroupMembersRequest) error {
+	return validation.ValidateStruct(in,
+		validation.Field(&in.GroupId, validation.Required, is.UUID),
+	)
+}
+
+func ValidateGetGroupMember(in *accountsv1.GetGroupMemberRequest) error {
+	return validation.ValidateStruct(in,
+		validation.Field(&in.GroupId, validation.Required, is.UUID),
+		validation.Field(&in.AccountId, validation.Required, is.UUID),
+	)
+}


### PR DESCRIPTION
#### Description

<!-- Optionally, briefly describe the changes -->

Main things in the PR:
Group models and enpoints modification
Member  logic implémentation 

FInally testing for groups and members Request !!! (add firework)

<!-- Include the ID of issue(s) related to this pull request -->

Related Us
#37 , #36, #38, #34, #35, #49 

#### Changelog

<!-- Provide a description of the technical changes introduced by your pull request
highlighting any breaking changes -->

- [UPDATE]
 - Group suppression remove all related members

- [ENHANCEMENT]
Members are store in another collection with, 
  -  Member creation function (without internal token logic), we need to discuss about this
  -  Member suppression with two main case ,  if lambda user, or if admin set another random member as Admin
  -  Listing of Groups from an account_id, no need to be same user as the account_id
  -  Listing of members in a group
  - Get Group from groupID

- [TODO]
  - For now i miss update Member information rpc, because exept for the created_at we don't store any information related to the member (RGPD compliance imao)