### PR TITLE
update Groups or Account prevent some field to be updated / ListGroupMembers and ListGroups pagination updated

### DIFF
--- a/groups.go
+++ b/groups.go
@@ -141,7 +141,11 @@ func (srv *groupsAPI) ListGroups(ctx context.Context, in *accountsv1.ListGroupsR
 		return nil, status.Error(codes.Unauthenticated, err.Error())
 	}
 
-	memberFromGroups, err := srv.memberRepo.List(ctx, &models.MemberFilter{AccountID: &in.AccountId})
+	if in.Limit == 0 {
+		in.Limit = 10
+	}
+
+	memberFromGroups, err := srv.memberRepo.List(ctx, &models.MemberFilter{AccountID: &in.AccountId}, &models.Pagination{Limit: int64(in.Limit), Offset: int64(in.Offset)})
 	if err != nil {
 		return nil, status.Error(codes.Unauthenticated, "could not list groups member from groups Id")
 	}

--- a/groups.go
+++ b/groups.go
@@ -145,7 +145,7 @@ func (srv *groupsAPI) ListGroups(ctx context.Context, in *accountsv1.ListGroupsR
 		in.Limit = 10
 	}
 
-	memberFromGroups, err := srv.memberRepo.List(ctx, &models.MemberFilter{AccountID: &in.AccountId}, &models.Pagination{Limit: int64(in.Limit), Offset: int64(in.Offset)})
+	memberFromGroups, err := srv.memberRepo.List(ctx, &models.MemberFilter{AccountID: &in.AccountId})
 	if err != nil {
 		return nil, status.Error(codes.Unauthenticated, "could not list groups member from groups Id")
 	}

--- a/groups.go
+++ b/groups.go
@@ -7,12 +7,10 @@ import (
 	"accounts-service/validators"
 	"context"
 
-	"github.com/jinzhu/copier"
 	"github.com/mennanov/fmutils"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -93,28 +91,16 @@ func (srv *groupsAPI) UpdateGroup(ctx context.Context, in *accountsv1.UpdateGrou
 		return nil, status.Error(codes.InvalidArgument, "invalid field mask")
 	}
 
-	acc, err := srv.groupRepo.Get(ctx, &models.OneGroupFilter{ID: in.Group.Id})
-	if err != nil {
-		return nil, statusFromModelError(err)
-	}
-
+	allowList := []string{"description", "name"}
 	fmutils.Filter(in.GetGroup(), fieldMask.GetPaths())
+	fmutils.Filter(in.GetGroup(), allowList)
 
-	var protoGroup accountsv1.Group
-	err = copier.Copy(&protoGroup, &acc)
-	if err != nil {
-		srv.logger.Error("invalid group conversion", zap.Error(err))
-		return nil, status.Error(codes.Internal, "could not update group")
-	}
-	proto.Merge(&protoGroup, in.Group)
-
-	updatedGroup, err := srv.groupRepo.Update(ctx, &models.OneGroupFilter{ID: acc.ID}, &models.GroupPayload{Name: &protoGroup.Name, Description: &protoGroup.Description})
+	_, err = srv.groupRepo.Update(ctx, &models.OneGroupFilter{ID: in.Group.Id}, &models.GroupPayload{Name: &in.GetGroup().Name, Description: &in.GetGroup().Description})
 	if err != nil {
 		return nil, statusFromModelError(err)
 	}
 
-	returnedGroup := accountsv1.Group{Id: updatedGroup.ID, Name: *updatedGroup.Name, Description: *updatedGroup.Description, CreatedAt: timestamppb.New(updatedGroup.CreatedAt)}
-	return &accountsv1.UpdateGroupResponse{Group: &returnedGroup}, nil
+	return &accountsv1.UpdateGroupResponse{Group: in.GetGroup()}, nil
 }
 
 func (srv *groupsAPI) GetGroup(ctx context.Context, in *accountsv1.GetGroupRequest) (*accountsv1.GetGroupResponse, error) {

--- a/groups_test.go
+++ b/groups_test.go
@@ -162,7 +162,7 @@ func (s *GroupsAPISuite) TestAddMembersToGroup() {
 	_, err = s.groupSrv.AddGroupMember(ctx, &accountsv1.AddGroupMemberRequest{GroupId: createGroupRes.Group.Id, AccountId: createAccountGabiRes.Account.Id})
 	s.Require().NoError(err)
 
-	listGroupMemberResp, err := s.groupSrv.ListGroupMembers(ctx, &accountsv1.ListGroupMembersRequest{GroupId: createGroupRes.Group.Id})
+	listGroupMemberResp, err := s.groupSrv.ListGroupMembers(ctx, &accountsv1.ListGroupMembersRequest{GroupId: createGroupRes.Group.Id, Limit: 10, Offset: 0})
 	s.Require().NoError(err)
 
 	s.Require().Equal(3, len(listGroupMemberResp.Members))
@@ -195,7 +195,7 @@ func (s *GroupsAPISuite) TestDeleteGroup() {
 	_, err = s.groupSrv.DeleteGroup(ctx, &accountsv1.DeleteGroupRequest{GroupId: createGroupRes.Group.Id})
 	s.Require().NoError(err)
 
-	listGroupMemberResp, err := s.groupSrv.ListGroupMembers(ctx, &accountsv1.ListGroupMembersRequest{GroupId: createGroupRes.Group.Id})
+	listGroupMemberResp, err := s.groupSrv.ListGroupMembers(ctx, &accountsv1.ListGroupMembersRequest{GroupId: createGroupRes.Group.Id, Limit: 10, Offset: 0})
 	s.Require().NoError(err)
 
 	s.Require().Equal(0, len(listGroupMemberResp.Members))
@@ -228,7 +228,7 @@ func (s *GroupsAPISuite) TestLeaveGroupAsAdmin() {
 	_, err = s.groupSrv.RemoveGroupMember(ctx, &accountsv1.RemoveGroupMemberRequest{GroupId: createGroupRes.Group.Id, AccountId: createAccountMaxRes.Account.Id})
 	s.Require().NoError(err)
 
-	listGroupMemberResp, err := s.groupSrv.ListGroupMembers(ctx, &accountsv1.ListGroupMembersRequest{GroupId: createGroupRes.Group.Id})
+	listGroupMemberResp, err := s.groupSrv.ListGroupMembers(ctx, &accountsv1.ListGroupMembersRequest{GroupId: createGroupRes.Group.Id, Limit: 10, Offset: 0})
 	s.Require().NoError(err)
 
 	isAdmin := false
@@ -273,7 +273,7 @@ func (s *GroupsAPISuite) TestRemoveAdminMemberAsUser() {
 	_, err = s.groupSrv.RemoveGroupMember(ctxBalthi, &accountsv1.RemoveGroupMemberRequest{GroupId: createGroupRes.Group.Id, AccountId: createAccountMaxRes.Account.Id})
 	s.Require().Error(err)
 
-	listGroupMemberResp, err := s.groupSrv.ListGroupMembers(ctx, &accountsv1.ListGroupMembersRequest{GroupId: createGroupRes.Group.Id})
+	listGroupMemberResp, err := s.groupSrv.ListGroupMembers(ctx, &accountsv1.ListGroupMembersRequest{GroupId: createGroupRes.Group.Id, Limit: 10, Offset: 0})
 	s.Require().NoError(err)
 
 	isAdmin := false
@@ -318,7 +318,7 @@ func (s *GroupsAPISuite) TestLeaveGroupAsUser() {
 	_, err = s.groupSrv.RemoveGroupMember(ctxBalthi, &accountsv1.RemoveGroupMemberRequest{GroupId: createGroupRes.Group.Id, AccountId: createAccountBalthiRes.Account.Id})
 	s.Require().NoError(err)
 
-	listGroupMemberResp, err := s.groupSrv.ListGroupMembers(ctx, &accountsv1.ListGroupMembersRequest{GroupId: createGroupRes.Group.Id})
+	listGroupMemberResp, err := s.groupSrv.ListGroupMembers(ctx, &accountsv1.ListGroupMembersRequest{GroupId: createGroupRes.Group.Id, Limit: 10, Offset: 0})
 	s.Require().NoError(err)
 
 	isAdmin := false
@@ -380,7 +380,7 @@ func (s *GroupsAPISuite) TestListGroupIBelongTo() {
 	_, err = s.groupSrv.CreateGroup(ctx, &accountsv1.CreateGroupRequest{Description: "description", Name: "Group5"})
 	s.Require().NoError(err)
 
-	listGroupRespGabi, err := s.groupSrv.ListGroups(ctx, &accountsv1.ListGroupsRequest{AccountId: createAccountGabiRes.Account.Id})
+	listGroupRespGabi, err := s.groupSrv.ListGroups(ctx, &accountsv1.ListGroupsRequest{AccountId: createAccountGabiRes.Account.Id, Limit: 10, Offset: 0})
 	s.Require().NoError(err)
 	s.Require().Equal(4, len(listGroupRespGabi.Groups))
 

--- a/members.go
+++ b/members.go
@@ -121,8 +121,13 @@ func (srv *groupsAPI) ListGroupMembers(ctx context.Context, in *accountsv1.ListG
 		return nil, status.Error(codes.Unauthenticated, err.Error())
 	}
 
+	if in.Limit == 0 {
+		in.Limit = 10
+	}
+
 	filter := models.MemberFilter{GroupID: &in.GroupId}
-	members, err := srv.memberRepo.List(ctx, &filter)
+	pagination := models.Pagination{Limit: int64(in.Limit), Offset: int64(in.Offset)}
+	members, err := srv.memberRepo.List(ctx, &filter, &pagination)
 	if err != nil {
 		return nil, status.Error(codes.Internal, "failed to list members")
 	}

--- a/models/members.go
+++ b/models/members.go
@@ -35,7 +35,7 @@ type MembersRepository interface {
 
 	Update(ctx context.Context, filter *MemberFilter, account *MemberPayload) (*Member, error)
 
-	List(ctx context.Context, filter *MemberFilter) ([]Member, error)
+	List(ctx context.Context, filter *MemberFilter, pagination *Pagination) ([]Member, error)
 
 	// SetAdmin(ctx context.Context, filter *MemberFilter) error
 }

--- a/models/members.go
+++ b/models/members.go
@@ -35,7 +35,7 @@ type MembersRepository interface {
 
 	Update(ctx context.Context, filter *MemberFilter, account *MemberPayload) (*Member, error)
 
-	List(ctx context.Context, filter *MemberFilter, pagination *Pagination) ([]Member, error)
+	List(ctx context.Context, filter *MemberFilter) ([]Member, error)
 
 	// SetAdmin(ctx context.Context, filter *MemberFilter) error
 }

--- a/models/memory/members.go
+++ b/models/memory/members.go
@@ -155,7 +155,7 @@ func (srv *membersRepository) Update(ctx context.Context, filter *models.MemberF
 	return &newAdmin, nil
 }
 
-func (srv *membersRepository) List(ctx context.Context, filter *models.MemberFilter, pagination *models.Pagination) ([]models.Member, error) {
+func (srv *membersRepository) List(ctx context.Context, filter *models.MemberFilter) ([]models.Member, error) {
 	var members []models.Member
 	var err error
 	var it memdb.ResultIterator

--- a/models/memory/members.go
+++ b/models/memory/members.go
@@ -155,7 +155,7 @@ func (srv *membersRepository) Update(ctx context.Context, filter *models.MemberF
 	return &newAdmin, nil
 }
 
-func (srv *membersRepository) List(ctx context.Context, filter *models.MemberFilter) ([]models.Member, error) {
+func (srv *membersRepository) List(ctx context.Context, filter *models.MemberFilter, pagination *models.Pagination) ([]models.Member, error) {
 	var members []models.Member
 	var err error
 	var it memdb.ResultIterator

--- a/models/mongo/accounts.go
+++ b/models/mongo/accounts.go
@@ -94,17 +94,16 @@ func (srv *accountsRepository) Delete(ctx context.Context, filter *models.OneAcc
 func (srv *accountsRepository) Update(ctx context.Context, filter *models.OneAccountFilter, account *models.AccountPayload) (*models.Account, error) {
 	var accountUpdated models.Account
 
-	after := options.After
-	opt := options.FindOneAndUpdateOptions{
-		ReturnDocument: &after,
-	}
+	field := bson.D{{"$set", bson.D{{"name", account.Name}}}}
+	update, err := srv.coll.UpdateOne(ctx, filter, field)
 
-	err := srv.coll.FindOneAndUpdate(ctx, filter, bson.D{{Key: "$set", Value: &account}}, &opt).Decode(&accountUpdated)
 	if err != nil {
 		srv.logger.Error("update one failed", zap.Error(err))
 		return nil, err
 	}
-
+	if update.ModifiedCount == 0 {
+		return nil, models.ErrNotFound
+	}
 	return &accountUpdated, nil
 }
 

--- a/models/mongo/members.go
+++ b/models/mongo/members.go
@@ -118,15 +118,15 @@ func (srv *membersRepository) Update(ctx context.Context, filter *models.MemberF
 	return &updatedMember, nil
 }
 
-func (srv *membersRepository) List(ctx context.Context, filter *models.MemberFilter) ([]models.Member, error) {
+func (srv *membersRepository) List(ctx context.Context, filter *models.MemberFilter, pagination *models.Pagination) ([]models.Member, error) {
 	var members []models.Member
 
-	// opt := options.FindOptions{
-	// 	Limit: &pagination.Limit,
-	// 	Skip:  &pagination.Offset,
-	// }
+	opt := options.FindOptions{
+		Limit: &pagination.Limit,
+		Skip:  &pagination.Offset,
+	}
 
-	cursor, err := srv.coll.Find(ctx, &filter)
+	cursor, err := srv.coll.Find(ctx, &filter, &opt)
 	if err != nil {
 		srv.logger.Error("mongo find members query failed", zap.Error(err))
 		return nil, err

--- a/models/mongo/members.go
+++ b/models/mongo/members.go
@@ -118,15 +118,10 @@ func (srv *membersRepository) Update(ctx context.Context, filter *models.MemberF
 	return &updatedMember, nil
 }
 
-func (srv *membersRepository) List(ctx context.Context, filter *models.MemberFilter, pagination *models.Pagination) ([]models.Member, error) {
+func (srv *membersRepository) List(ctx context.Context, filter *models.MemberFilter) ([]models.Member, error) {
 	var members []models.Member
 
-	opt := options.FindOptions{
-		Limit: &pagination.Limit,
-		Skip:  &pagination.Offset,
-	}
-
-	cursor, err := srv.coll.Find(ctx, &filter, &opt)
+	cursor, err := srv.coll.Find(ctx, &filter)
 	if err != nil {
 		srv.logger.Error("mongo find members query failed", zap.Error(err))
 		return nil, err

--- a/validators/groups.go
+++ b/validators/groups.go
@@ -20,7 +20,11 @@ func ValidateUpdatedGroupRequest(in *accountsv1.UpdateGroupRequest) error {
 }
 
 func ValidateListGroups(in *accountsv1.ListGroupsRequest) error {
-	return validation.Validate(&in.AccountId, validation.Required, is.UUID)
+	return validation.ValidateStruct(in,
+		validation.Field(&in.AccountId, validation.Required, is.UUID),
+		validation.Field(&in.Limit, validation.When(in.Limit != 0, validation.Required), validation.Min(0)),
+		validation.Field(&in.Offset, validation.When(in.Offset != 0, validation.Required), validation.Min(0)),
+	)
 }
 
 func ValidateGetGroup(in *accountsv1.GetGroupRequest) error {

--- a/validators/groups.go
+++ b/validators/groups.go
@@ -20,11 +20,21 @@ func ValidateUpdatedGroupRequest(in *accountsv1.UpdateGroupRequest) error {
 }
 
 func ValidateListGroups(in *accountsv1.ListGroupsRequest) error {
-	return validation.ValidateStruct(in,
+	err := validation.ValidateStruct(in,
 		validation.Field(&in.AccountId, validation.Required, is.UUID),
-		validation.Field(&in.Limit, validation.When(in.Limit != 0, validation.Required), validation.Min(0)),
-		validation.Field(&in.Offset, validation.When(in.Offset != 0, validation.Required), validation.Min(0)),
 	)
+	if err != nil {
+		return err
+	}
+	err = validation.Validate(in.Limit, validation.When(in.Limit != 0, validation.Required), validation.Min(0))
+	if err != nil {
+		return err
+	}
+	err = validation.Validate(in.Offset, validation.When(in.Offset != 0, validation.Required), validation.Min(0))
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func ValidateGetGroup(in *accountsv1.GetGroupRequest) error {

--- a/validators/members.go
+++ b/validators/members.go
@@ -29,11 +29,21 @@ func ValidateUpdateGroupMember(in *accountsv1.UpdateGroupMemberRequest) error {
 }
 
 func ValidateListGroupMember(in *accountsv1.ListGroupMembersRequest) error {
-	return validation.ValidateStruct(in,
+	err := validation.ValidateStruct(in,
 		validation.Field(&in.GroupId, validation.Required, is.UUID),
-		validation.Field(&in.Limit, validation.When(in.Limit != 0, validation.Required), validation.Min(0)),
-		validation.Field(&in.Offset, validation.When(in.Offset != 0, validation.Required), validation.Min(0)),
 	)
+	if err != nil {
+		return err
+	}
+	err = validation.Validate(in.Limit, validation.When(in.Limit != 0, validation.Required), validation.Min(0))
+	if err != nil {
+		return err
+	}
+	err = validation.Validate(in.Offset, validation.When(in.Offset != 0, validation.Required), validation.Min(0))
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func ValidateGetGroupMember(in *accountsv1.GetGroupMemberRequest) error {

--- a/validators/members.go
+++ b/validators/members.go
@@ -24,13 +24,15 @@ func ValidateRemoveGroupMember(in *accountsv1.RemoveGroupMemberRequest) error {
 func ValidateUpdateGroupMember(in *accountsv1.UpdateGroupMemberRequest) error {
 	return validation.ValidateStruct(in,
 		validation.Field(&in.GroupId, validation.Required, is.UUID),
-		validation.Field(&in.AccountId, validation.Required, is.UUID),
+		validation.Field(&in.Member, validation.Required, is.UUID),
 	)
 }
 
 func ValidateListGroupMember(in *accountsv1.ListGroupMembersRequest) error {
 	return validation.ValidateStruct(in,
 		validation.Field(&in.GroupId, validation.Required, is.UUID),
+		validation.Field(&in.Limit, validation.When(in.Limit != 0, validation.Required), validation.Min(0)),
+		validation.Field(&in.Offset, validation.When(in.Offset != 0, validation.Required), validation.Min(0)),
 	)
 }
 


### PR DESCRIPTION
#### Description

<!-- Optionally, briefly describe the changes -->
ListGroups: Validate Pagination and set ```Limit``` to 10 if no other value is specified,
ListGroupMembers: Validate Pagination and set ```Limit```  to 10 if no other value is specified 

Update Group and Account: add allow List to update only expected field (name and description)

#### Changelog

<!-- Provide a description of the technical changes introduced by your pull request
highlighting any breaking changes -->  

- [BUGFIX]
- [ENHANCEMENT]
Update Group and Account: add allow List to update only expected field    
