### PR TITLE
Fix list invites filter, validator and auth

### DIFF
--- a/auth/test_service.go
+++ b/auth/test_service.go
@@ -1,0 +1,48 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"google.golang.org/grpc/metadata"
+)
+
+type TestService struct {
+}
+
+var _ Service = &TestService{}
+
+func (srv *TestService) ContextWithToken(parent context.Context, token *Token) (context.Context, error) {
+	ss, err := json.Marshal(token)
+	if err != nil {
+		return nil, err
+	}
+	return metadata.AppendToOutgoingContext(parent, AuthorizationHeaderKey, fmt.Sprint(AuthorizationHeaderPrefix, " ", string(ss))), nil
+}
+
+func (srv *TestService) TokenFromContext(ctx context.Context) (*Token, error) {
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		return nil, ErrNoMetadataInCtx
+	}
+
+	values := md.Get(AuthorizationHeaderKey)
+	tokenString := ""
+
+	for i := range values {
+		tokenString, ok = TokenFromAuthorizationHeader(values[i])
+		if ok {
+			break
+		}
+	}
+
+	if tokenString == "" {
+		return nil, ErrNoTokenInCtx
+	}
+
+	token := &Token{}
+	json.Unmarshal([]byte(tokenString), token)
+
+	return token, nil
+}

--- a/auth/test_service.go
+++ b/auth/test_service.go
@@ -46,3 +46,8 @@ func (srv *TestService) TokenFromContext(ctx context.Context) (*Token, error) {
 
 	return token, nil
 }
+
+// NOTE: Not sure but works for conversations tests
+func (srv *TestService) SignToken(info *Token) (string, error) {
+	return "", nil
+}

--- a/auth/test_service_test.go
+++ b/auth/test_service_test.go
@@ -1,0 +1,23 @@
+package auth_test
+
+import (
+	"context"
+	"notes-service/auth"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTestService(t *testing.T) {
+	service := &auth.TestService{}
+
+	uid := uuid.Must(uuid.NewRandom())
+	token, err := service.ContextWithToken(context.TODO(), &auth.Token{UserID: uid, Role: "admin"})
+	require.NoError(t, err)
+
+	info, err := service.TokenFromContext(token)
+	require.NoError(t, err)
+	require.Equal(t, info.UserID, uid)
+	require.Equal(t, info.Role, "admin")
+}

--- a/auth/test_service_test.go
+++ b/auth/test_service_test.go
@@ -1,8 +1,8 @@
 package auth_test
 
 import (
+	"accounts-service/auth"
 	"context"
-	"notes-service/auth"
 	"testing"
 
 	"github.com/google/uuid"

--- a/invites.go
+++ b/invites.go
@@ -142,16 +142,20 @@ func (srv *invitesAPI) ListInvites(ctx context.Context, in *accountsv1.ListInvit
 		in.Limit = 20
 	}
 
+	nilIfEmpty := func(s string) *string {
+		if s == "" {
+			return nil
+		}
+		return &s
+	}
 	invites, err := srv.inviteRepo.List(ctx, &models.ManyInvitesFilter{
-		SenderAccountID:    &in.SenderAccountId,
-		RecipientAccountID: &in.RecipientAccountId,
-		GroupID:            &in.GroupId,
+		SenderAccountID:    nilIfEmpty(in.SenderAccountId),
+		RecipientAccountID: nilIfEmpty(in.RecipientAccountId),
+		GroupID:            nilIfEmpty(in.GroupId),
 	}, &models.Pagination{Offset: int64(in.Offset), Limit: int64(in.Limit)})
 	if err != nil {
 		return nil, statusFromModelError(err)
 	}
-
-	// NOTE: As every account are apparently accessible to list and get from every account as long as you are authentificated, I did the same with invites
 
 	var inviteResp []*accountsv1.Invite
 	for _, invite := range invites {

--- a/models/mongo/accounts.go
+++ b/models/mongo/accounts.go
@@ -94,7 +94,7 @@ func (srv *accountsRepository) Delete(ctx context.Context, filter *models.OneAcc
 func (srv *accountsRepository) Update(ctx context.Context, filter *models.OneAccountFilter, account *models.AccountPayload) (*models.Account, error) {
 	var accountUpdated models.Account
 
-	field := bson.D{{"$set", bson.D{{"name", account.Name}}}}
+	field := bson.D{{Key: "$set", Value: bson.D{{"name", account.Name}}}}
 	update, err := srv.coll.UpdateOne(ctx, filter, field)
 
 	if err != nil {

--- a/models/mongo/invites.go
+++ b/models/mongo/invites.go
@@ -119,19 +119,8 @@ func (srv *invitesRepository) List(ctx context.Context, filter *models.ManyInvit
 		Limit: &pagination.Limit,
 		Skip:  &pagination.Offset,
 	}
-	f := bson.D{}
 
-	if filter.GroupID != nil && (*filter.GroupID) != "" {
-		f = append(f, bson.E{Key: "group_id", Value: filter.GroupID})
-	}
-	if filter.RecipientAccountID != nil && (*filter.RecipientAccountID) != "" {
-		f = append(f, bson.E{Key: "recipient_account_id", Value: filter.RecipientAccountID})
-	}
-	if filter.SenderAccountID != nil && (*filter.SenderAccountID) != "" {
-		f = append(f, bson.E{Key: "sender_account_id", Value: filter.SenderAccountID})
-	}
-
-	cursor, err := srv.coll.Find(ctx, f, &opt)
+	cursor, err := srv.coll.Find(ctx, &filter, &opt)
 	if err != nil {
 		srv.logger.Error("mongo find invites query failed", zap.Error(err))
 		return nil, err

--- a/models/mongo/invites.go
+++ b/models/mongo/invites.go
@@ -119,7 +119,19 @@ func (srv *invitesRepository) List(ctx context.Context, filter *models.ManyInvit
 		Limit: &pagination.Limit,
 		Skip:  &pagination.Offset,
 	}
-	cursor, err := srv.coll.Find(ctx, bson.D{}, &opt)
+	f := bson.D{}
+
+	if filter.GroupID != nil && (*filter.GroupID) != "" {
+		f = append(f, bson.E{Key: "group_id", Value: filter.GroupID})
+	}
+	if filter.RecipientAccountID != nil && (*filter.RecipientAccountID) != "" {
+		f = append(f, bson.E{Key: "recipient_account_id", Value: filter.RecipientAccountID})
+	}
+	if filter.SenderAccountID != nil && (*filter.SenderAccountID) != "" {
+		f = append(f, bson.E{Key: "sender_account_id", Value: filter.SenderAccountID})
+	}
+
+	cursor, err := srv.coll.Find(ctx, f, &opt)
 	if err != nil {
 		srv.logger.Error("mongo find invites query failed", zap.Error(err))
 		return nil, err

--- a/validators/invites.go
+++ b/validators/invites.go
@@ -27,11 +27,7 @@ func ValidateDenyInvite(in *accountsv1.DenyInviteRequest) error {
 }
 
 func ValidateListInvites(in *accountsv1.ListInvitesRequest) error {
-	return validation.ValidateStruct(in,
-		validation.Field(&in.SenderAccountId, validation.Required, is.UUID),
-		validation.Field(&in.RecipientAccountId, validation.Required, is.UUID),
-		validation.Field(&in.GroupId, validation.Required, is.UUID),
-	)
+	return nil
 }
 
 func ValidateGetInvite(in *accountsv1.GetInviteRequest) error {

--- a/validators/invites.go
+++ b/validators/invites.go
@@ -27,7 +27,11 @@ func ValidateDenyInvite(in *accountsv1.DenyInviteRequest) error {
 }
 
 func ValidateListInvites(in *accountsv1.ListInvitesRequest) error {
-	return nil
+	return validation.ValidateStruct(in,
+		validation.Field(&in.GroupId, is.UUID),
+		validation.Field(&in.SenderAccountId, is.UUID),
+		validation.Field(&in.RecipientAccountId, is.UUID),
+	)
 }
 
 func ValidateGetInvite(in *accountsv1.GetInviteRequest) error {


### PR DESCRIPTION
fix: validator list invites

#### Description

Quick fix for invites filter and validator
Auth check for invites

Filter management was based on accounts `List` which turned out to be wrong

NOTE: If a user wants to list every one of his invite, he HAS to put his ID as recipient/sender ID, hope that's ok, it can always be changed

#### Changelog

- [ENHANCEMENT] Auth check for invites
- [ENHANCEMENT] Basic unit test for list invite
- [BUGFIX] List validator
- [BUGFIX] List filter
