### PR TITLE
forgot password flow

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -7,6 +7,8 @@ import (
 	"accounts-service/validators"
 	"context"
 	"errors"
+	"fmt"
+	"time"
 
 	"github.com/mennanov/fmutils"
 	"go.uber.org/zap"
@@ -23,6 +25,7 @@ type accountsAPI struct {
 	auth   auth.Service
 	logger *zap.Logger
 	repo   models.AccountsRepository
+	mail   mailingAPI
 }
 
 var _ accountsv1.AccountsAPIServer = &accountsAPI{}
@@ -160,6 +163,114 @@ func (srv *accountsAPI) ListAccounts(ctx context.Context, in *accountsv1.ListAcc
 		accountsResp = append(accountsResp, elem)
 	}
 	return &accountsv1.ListAccountsResponse{Accounts: accountsResp}, nil
+}
+
+func (srv *accountsAPI) ForgetAccountPassword(ctx context.Context, in *accountsv1.ForgetAccountPasswordRequest) (*accountsv1.ForgetAccountPasswordResponse, error) {
+	err := validators.ValidateForgetAccountPasswordRequest(in)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	accountToken, err := srv.repo.UpdateAccountWithResetPasswordToken(ctx, &models.OneAccountFilter{Email: in.Email})
+	if err != nil {
+		return nil, statusFromModelError(err)
+	}
+
+	body := fmt.Sprintf(`<span>Bonjour,<br/>Nous avons reçu une demande pour réinitialiser votre mot de passe.
+		<br/>Si vous n'avez pas fait la demande, ignorez simplement ce message.
+		<br/>Sinon, vous pouvez réinitialiser votre mot de passe.
+		<br/>Attention, votre code n'est valable qu'une heure.
+		<br/><div style="padding:16px 24px;border:1px solid #eeeeee;background-color:#f4f4f4;
+		border-radius:3px;font-family:monospace;margin:24px 0px 24px 0px ">%s</div></span>`, accountToken.Token)
+
+	emailInformation := &SendEmailsRequest{
+		to:      []string{accountToken.ID},
+		title:   "mis à jour Mot de passe",
+		subject: "Réinitialisez votre mot de passe",
+		body:    body,
+	}
+	err = srv.mail.SendEmails(ctx, emailInformation)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	return &accountsv1.ForgetAccountPasswordResponse{AccountId: accountToken.ID, ValidUntil: accountToken.ValidUntil.String()}, nil
+}
+
+func (srv *accountsAPI) ForgetAccountPasswordValidateToken(ctx context.Context, in *accountsv1.ForgetAccountPasswordValidateTokenRequest) (*accountsv1.ForgetAccountPasswordValidateTokenResponse, error) {
+	err := validators.ValidateForgetAccountPasswordValidateTokenRequest(in)
+	if err != nil || in.AccountId == "" {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	acc, err := srv.repo.Get(ctx, &models.OneAccountFilter{ID: in.AccountId})
+	if err != nil {
+		return nil, statusFromModelError(err)
+	}
+
+	if acc.Token != in.Token {
+		return nil, status.Error(codes.NotFound, "reset-token does not match")
+	}
+
+	if !time.Now().UTC().Before(acc.ValidUntil) {
+		return nil, status.Error(codes.InvalidArgument, "reset-token expire")
+	}
+
+	tokenString, err := srv.auth.SignToken(&auth.Token{AccountID: acc.ID})
+	if err != nil {
+		srv.logger.Error("failed to sign token", zap.Error(err))
+		return nil, status.Error(codes.Internal, "failed to authenticate user")
+	}
+
+	return &accountsv1.ForgetAccountPasswordValidateTokenResponse{Account: modelsAccountToProtobufAccount(acc), ResetToken: acc.Token, AuthToken: tokenString}, nil
+}
+
+func (srv *accountsAPI) UpdateAccountPassword(ctx context.Context, in *accountsv1.UpdateAccountPasswordRequest) (*accountsv1.UpdateAccountPasswordResponse, error) {
+	_, err := srv.authenticate(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	err = validators.ValidateUpdateAccountPasswordRequest(in)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	var acc *models.Account
+	if in.OldPassword != "" {
+		acc, err = srv.repo.Get(ctx, &models.OneAccountFilter{ID: in.AccountId})
+		if err != nil {
+			return nil, statusFromModelError(err)
+		}
+		err = bcrypt.CompareHashAndPassword(*acc.Hash, []byte(in.OldPassword))
+		if err != nil {
+			return nil, status.Error(codes.InvalidArgument, "password does not match")
+		}
+	} else if in.Token != "" {
+		acc, err = srv.repo.Get(ctx, &models.OneAccountFilter{ID: in.AccountId})
+		if err != nil {
+			return nil, statusFromModelError(err)
+		}
+		if acc.Token != in.Token {
+			return nil, status.Error(codes.NotFound, "reset-token does not match")
+		}
+
+		if !time.Now().UTC().Before(acc.ValidUntil) {
+			return nil, status.Error(codes.InvalidArgument, "reset-token expire")
+		}
+	} else {
+		return nil, status.Error(codes.InvalidArgument, "missing argument, old password or reset password token")
+	}
+
+	hashed, err := bcrypt.GenerateFromPassword([]byte(in.Password), 8)
+	if err != nil {
+		srv.logger.Error("bcrypt failed to hash password", zap.Error(err))
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	acc, err = srv.repo.UpdateAccountPassword(ctx, &models.OneAccountFilter{ID: in.AccountId}, &models.AccountPayload{Hash: &hashed})
+	if err != nil {
+		return nil, statusFromModelError(err)
+	}
+	return &accountsv1.UpdateAccountPasswordResponse{Account: modelsAccountToProtobufAccount(acc)}, nil
 }
 
 func (srv *accountsAPI) Authenticate(ctx context.Context, in *accountsv1.AuthenticateRequest) (*accountsv1.AuthenticateResponse, error) {

--- a/mailing.go
+++ b/mailing.go
@@ -2,13 +2,10 @@ package main
 
 import (
 	"accounts-service/models"
-	mailingv1 "accounts-service/protorepo/noted/mailing/v1"
-	"accounts-service/validators"
 	"bytes"
 	"context"
 	"html/template"
 	"net/smtp"
-	"os"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
@@ -19,13 +16,10 @@ import (
 )
 
 type mailingAPI struct {
-	mailingv1.UnimplementedMailingAPIServer
-
 	logger *zap.Logger
 	repo   models.AccountsRepository
+	secret string
 }
-
-var _ mailingv1.MailingAPIServer = &mailingAPI{}
 
 type TemplateData struct {
 	CODE    string
@@ -38,7 +32,13 @@ type Request struct {
 	to      []string
 	subject string
 	body    string
-	super   []byte
+}
+
+type SendEmailsRequest struct {
+	to      []string
+	subject string
+	title   string
+	body    string
 }
 
 func NewRequest(from string, to []string, subject, body string) *Request {
@@ -50,19 +50,14 @@ func NewRequest(from string, to []string, subject, body string) *Request {
 	}
 }
 
-func (r *Request) SendEmailToAccounts() error {
+func (r *Request) SendEmailToAccounts(secret string) error {
+
 	subject := "Subject: " + r.subject + "!\n"
 	mine := "MIME-version: 1.0;\nContent-Type: text/html; charset=\"UTF-8\";\n\n"
 	msg := []byte(subject + mine + r.body)
 	addr := "smtp.gmail.com:587"
-	ssPassword := os.Getenv("GMAIL_SUPER_SECRET")
 
-	if ssPassword == "" {
-		return status.Error(codes.Internal, "could not retrieve super secret from environement")
-	}
-
-	auth := smtp.PlainAuth("", r.from, string(ssPassword), "smtp.gmail.com")
-
+	auth := smtp.PlainAuth("", r.from, secret, "smtp.gmail.com")
 	if err := smtp.SendMail(addr, auth, r.from, r.to, msg); err != nil {
 		return err
 	}
@@ -83,45 +78,41 @@ func (r *Request) ParseTemplate(templateFileName string, data interface{}) error
 	return nil
 }
 
-func (srv *mailingAPI) SendEmails(ctx context.Context, in *mailingv1.SendEmailsRequest) (*mailingv1.SendEmailsResponse, error) {
+func (srv *mailingAPI) SendEmails(ctx context.Context, req *SendEmailsRequest) error {
 
-	err := validators.ValidateSendEmailsRequest(in)
-	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+	if srv.secret == "" {
+		return status.Error(codes.Internal, "could not retrieve super secret from environement")
 	}
 
 	filters := []*models.OneAccountFilter{}
-
-	for _, val := range in.Recipients {
-		filters = append(filters, &models.OneAccountFilter{ID: val.AccountId})
+	for _, accountID := range req.to {
+		filters = append(filters, &models.OneAccountFilter{ID: accountID})
 	}
 
 	mails, err := srv.repo.GetMailsFromIDs(ctx, filters)
 	if err != nil {
-		return nil, statusFromModelError(err)
+		return statusFromModelError(err)
 	}
 
 	extensions := parser.CommonExtensions | parser.AutoHeadingIDs
 	parser := parser.NewWithExtensions(extensions)
-
-	md := []byte(in.MarkdownBody)
+	md := []byte(req.body)
 	html := markdown.ToHTML(md, parser, nil)
-
 	content := template.HTML(string(html[:]))
 
 	templateData := TemplateData{
 		CONTENT: content,
-		TITLE:   in.Title,
+		TITLE:   req.title,
 	}
 
-	r := NewRequest("noted.organisation@gmail.com", mails, in.Subject, in.MarkdownBody)
+	r := NewRequest("noted.organisation@gmail.com", mails, req.subject, req.body)
 	err = r.ParseTemplate("ressources/mail.html", templateData)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return status.Error(codes.Internal, err.Error())
 	}
-	err = r.SendEmailToAccounts()
+	err = r.SendEmailToAccounts(srv.secret)
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return status.Error(codes.Internal, err.Error())
 	}
-	return &mailingv1.SendEmailsResponse{}, nil
+	return nil
 }

--- a/mails_content.go
+++ b/mails_content.go
@@ -1,0 +1,28 @@
+package main
+
+import "fmt"
+
+type SendEmailsRequest struct {
+	to      []string
+	sender  string
+	subject string
+	title   string
+	body    string
+}
+
+func ForgetAccountPasswordMailContent(accountID string, token string) *SendEmailsRequest {
+	body := fmt.Sprintf(`<span>Bonjour,<br/>Nous avons reçu une demande pour réinitialiser votre mot de passe.
+		<br/>Si vous n'avez pas fait la demande, ignorez simplement ce message.
+		<br/>Sinon, vous pouvez réinitialiser votre mot de passe.
+		<br/>Attention, votre code n'est valable qu'une heure.
+		<br/><div style="padding:16px 24px;border:1px solid #eeeeee;background-color:#f4f4f4;
+		border-radius:3px;font-family:monospace;margin:24px 0px 24px 0px ">%s</div></span>`, token)
+
+	return &SendEmailsRequest{
+		to:      []string{accountID},
+		sender:  "noted.organisation@gmail.com",
+		title:   "Mise à jour de mot de passe",
+		subject: "Réinitialisez votre mot de passe",
+		body:    body,
+	}
+}

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ var (
 	mongoUri         = app.Flag("mongo-uri", "address of the mongodb server").Default("mongodb://localhost:27017").String()
 	mongoDbName      = app.Flag("mongo-db-name", "name of the mongo database").Default("accounts-service").String()
 	jwtPrivateKey    = app.Flag("jwt-private-key", "base64 encoded ed25519 private key").Default("SGfCQAb05CtmhEesWxcrfXSQR6JjmEMeyjR7Mo21S60ZDW9VVTUuCvEMlGjlqiw4I/z8T11KqAXexvGIPiuffA==").String()
-  gmailSuperSecret = app.Flag("gmail-super-secret", "token to authenticate accounts service with noted gmail account").Default("").String()
+	gmailSuperSecret = app.Flag("gmail-super-secret", "token to authenticate accounts service with noted gmail account").Default("").String()
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -12,11 +12,12 @@ import (
 var (
 	app = kingpin.New("accounts-service", "Accounts service for the Noted backend").DefaultEnvars()
 
-	environment   = app.Flag("env", "either development or production").Default(envIsProd).Enum(envIsProd, envIsDev)
-	port          = app.Flag("port", "grpc server port").Default("3000").Int16()
-	mongoUri      = app.Flag("mongo-uri", "address of the mongodb server").Default("mongodb://localhost:27017").String()
-	mongoDbName   = app.Flag("mongo-db-name", "name of the mongo database").Default("accounts-service").String()
-	jwtPrivateKey = app.Flag("jwt-private-key", "base64 encoded ed25519 private key").Default("SGfCQAb05CtmhEesWxcrfXSQR6JjmEMeyjR7Mo21S60ZDW9VVTUuCvEMlGjlqiw4I/z8T11KqAXexvGIPiuffA==").String()
+	environment      = app.Flag("env", "either development or production").Default(envIsProd).Enum(envIsProd, envIsDev)
+	port             = app.Flag("port", "grpc server port").Default("3000").Int16()
+	mongoUri         = app.Flag("mongo-uri", "address of the mongodb server").Default("mongodb://localhost:27017").String()
+	mongoDbName      = app.Flag("mongo-db-name", "name of the mongo database").Default("accounts-service").String()
+	jwtPrivateKey    = app.Flag("jwt-private-key", "base64 encoded ed25519 private key").Default("SGfCQAb05CtmhEesWxcrfXSQR6JjmEMeyjR7Mo21S60ZDW9VVTUuCvEMlGjlqiw4I/z8T11KqAXexvGIPiuffA==").String()
+	gmailSuperSecret = app.Flag("gmail-super-secret", "token to authenticate accounts service with noted gmail account").Default("").String()
 )
 
 var (

--- a/models/accounts.go
+++ b/models/accounts.go
@@ -2,13 +2,16 @@ package models
 
 import (
 	"context"
+	"time"
 )
 
 type Account struct {
-	ID    string  `json:"id" bson:"_id,omitempty"`
-	Email *string `json:"email" bson:"email,omitempty"`
-	Name  *string `json:"name" bson:"name,omitempty"`
-	Hash  *[]byte `json:"hash" bson:"hash,omitempty"`
+	ID         string    `json:"id" bson:"_id,omitempty"`
+	Email      *string   `json:"email" bson:"email,omitempty"`
+	Name       *string   `json:"name" bson:"name,omitempty"`
+	Hash       *[]byte   `json:"hash" bson:"hash,omitempty"`
+	Token      string    `json:"token" bson:"token,omitempty"`
+	ValidUntil time.Time `json:"valid_until" bson:"valid_until,omitempty"`
 }
 
 type AccountPayload struct {
@@ -20,6 +23,12 @@ type AccountPayload struct {
 type OneAccountFilter struct {
 	ID    string `json:"id" bson:"_id,omitempty"`
 	Email string `json:"email" bson:"email,omitempty"`
+}
+
+type AccountSecretToken struct {
+	ID         string    `json:"id" bson:"_id,omitempty"`
+	Token      string    `json:"token" bson:"token,omitempty"`
+	ValidUntil time.Time `json:"valid_until" bson:"valid_until,omitempty"`
 }
 
 type ManyAccountsFilter struct{}
@@ -37,4 +46,8 @@ type AccountsRepository interface {
 	Update(ctx context.Context, filter *OneAccountFilter, account *AccountPayload) (*Account, error)
 
 	List(ctx context.Context, filter *ManyAccountsFilter, pagination *Pagination) ([]Account, error)
+
+	UpdateAccountWithResetPasswordToken(ctx context.Context, filter *OneAccountFilter) (*AccountSecretToken, error)
+
+	UpdateAccountPassword(ctx context.Context, filter *OneAccountFilter, account *AccountPayload) (*Account, error)
 }

--- a/server.go
+++ b/server.go
@@ -130,18 +130,18 @@ func (s *server) initRepositories() {
 
 func (s *server) initAccountsAPI() {
 
-	mail := mailingAPI{
+	mailService := mailingAPI{
 		logger: s.logger,
 		repo:   s.accountsRepository,
 		secret: *gmailSuperSecret,
-  }
+	}
 
-  s.accountsService = &accountsAPI{
+	s.accountsService = &accountsAPI{
 		noteService: s.noteService,
+		mailService: mailService,
 		auth:        s.authService,
 		logger:      s.logger,
 		repo:        s.accountsRepository,
-    mail:        mail,
 	}
 }
 

--- a/validators/accounts.go
+++ b/validators/accounts.go
@@ -58,3 +58,22 @@ func ValidateListRequest(in *accountsv1.ListAccountsRequest) error {
 	}
 	return nil
 }
+
+func ValidateForgetAccountPasswordRequest(in *accountsv1.ForgetAccountPasswordRequest) error {
+	return validation.ValidateStruct(in,
+		validation.Field(&in.Email, validation.Required, is.Email))
+}
+
+func ValidateForgetAccountPasswordValidateTokenRequest(in *accountsv1.ForgetAccountPasswordValidateTokenRequest) error {
+	return validation.ValidateStruct(in,
+		validation.Field(&in.Token, validation.Required, validation.Length(4, 4)))
+}
+
+func ValidateUpdateAccountPasswordRequest(in *accountsv1.UpdateAccountPasswordRequest) error {
+	return validation.ValidateStruct(in,
+		validation.Field(&in.AccountId, validation.Required),
+		validation.Field(&in.Password, validation.Required, validation.Length(4, 20)),
+		validation.Field(&in.Token, validation.When(in.Token != ""), validation.Length(4, 4)),
+		validation.Field(&in.OldPassword, validation.When(in.OldPassword != ""), validation.Length(4, 20)),
+	)
+}

--- a/validators/accounts.go
+++ b/validators/accounts.go
@@ -66,7 +66,8 @@ func ValidateForgetAccountPasswordRequest(in *accountsv1.ForgetAccountPasswordRe
 
 func ValidateForgetAccountPasswordValidateTokenRequest(in *accountsv1.ForgetAccountPasswordValidateTokenRequest) error {
 	return validation.ValidateStruct(in,
-		validation.Field(&in.Token, validation.Required, validation.Length(4, 4)))
+		validation.Field(&in.Token, validation.Required, validation.Length(4, 4)),
+		validation.Field(&in.AccountId, validation.Required, validation.NotNil))
 }
 
 func ValidateUpdateAccountPasswordRequest(in *accountsv1.UpdateAccountPasswordRequest) error {


### PR DESCRIPTION
#### Description

<!-- Optionally, briefly describe the changes -->
ForgotAccountPassword send an email to the account with a 4 digit reset token.
Then we call ForgetAccountPasswordValidateToken to identify the unknow user and authenticate the account, 
Finally we call UpdateAccountPassword, we can use the old password or the reset token to set the new password

!! The reset-token is only valid 1 hour !!

You can find unit test for use case

---
New env variable for gmail-super-secret 

<!-- Include the ID of issue(s) related to this pull request -->

Fixes #80

#### Changelog

<!-- Provide a description of the technical changes introduced by your pull request
highlighting any breaking changes -->

- [BUGFIX]
- [ENHANCEMENT]
- [DOCS]
- ...
