### PR TITLE
Endpoint GetMailsFromIDs

### DIFF
--- a/accounts.go
+++ b/accounts.go
@@ -100,6 +100,29 @@ func (srv *accountsAPI) GetAccount(ctx context.Context, in *accountsv1.GetAccoun
 	return &accountsv1.GetAccountResponse{Account: modelsAccountToProtobufAccount(account)}, nil
 }
 
+// NOTE : Function dedicated to services only
+func (srv *accountsAPI) GetMailsFromIDsInternal(ctx context.Context, accountsIDs *[]string) (*[]string, error) {
+	_, err := srv.authenticate(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	err = validators.ValidateGetMailsFromIDsInternal(accountsIDs)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	filters := []*models.OneAccountFilter{}
+	for _, accountID := range *accountsIDs {
+		filters = append(filters, &models.OneAccountFilter{ID: accountID})
+	}
+	mails, err := srv.repo.GetMailsFromIDs(ctx, filters)
+	if err != nil {
+		return nil, statusFromModelError(err)
+	}
+	return &mails, nil
+}
+
 func (srv *accountsAPI) UpdateAccount(ctx context.Context, in *accountsv1.UpdateAccountRequest) (*accountsv1.UpdateAccountResponse, error) {
 	token, err := srv.authenticate(ctx)
 	if err != nil {

--- a/validators/accounts.go
+++ b/validators/accounts.go
@@ -25,6 +25,18 @@ func ValidateGetAccountRequest(in *accountsv1.GetAccountRequest) error {
 	)
 }
 
+func ValidateGetMailsFromIDsInternal(accountsIDs *[]string) error {
+	var err error = nil
+
+	if len(*accountsIDs) <= 0 {
+		return errors.New("Accounts Id list is nil or empty")
+	}
+	for _, id := range *accountsIDs {
+		err = validation.Validate(id, validation.Required)
+	}
+	return err
+}
+
 func ValidateUpdateAccountRequest(in *accountsv1.UpdateAccountRequest) error {
 	err := validation.Validate(in.AccountId, validation.Required)
 	if err != nil {


### PR DESCRIPTION
#### Description

Méthode `GetMailsFromIDsInternal` qui sera utilisé dans les autres service pour Get les emails et ensuite appeler le mailing-service.

Fixes #110 

#### Changelog

Nouvelle méthode dans le package main & nouveau validator
Le check du token est fait.
La route n'est pas publique pour que les clients web ne puissent pas requeter et recevoir les emails des utilisateurs.
Aucun test n'as été fait car les TU utilisent les endpoints généré par les .proto de l'account-service. Et cette méthode n'est pas disponible dans protorepo comme dis précédement.